### PR TITLE
feat: Phase 3 — splash UX redesign

### DIFF
--- a/lib/router/hark_router.dart
+++ b/lib/router/hark_router.dart
@@ -26,15 +26,12 @@ final goRouterProvider = Provider<GoRouter>((ref) {
   final refresh = _RouterRefreshListenable();
   ref.onDispose(refresh.dispose);
 
-  ref.listen<InitState>(
-    initProvider,
-    (previous, next) {
-      final wasReady = previous?.isReady ?? false;
-      if (wasReady != next.isReady) {
-        refresh.notify();
-      }
-    },
-  );
+  ref.listen<InitState>(initProvider, (previous, next) {
+    final wasProceedable = previous?.canProceed ?? false;
+    if (wasProceedable != next.canProceed) {
+      refresh.notify();
+    }
+  });
 
   return GoRouter(
     initialLocation: HarkRoutes.splash,
@@ -44,10 +41,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       final init = ref.read(initProvider);
       final atSplash = state.matchedLocation == HarkRoutes.splash;
 
-      if (atSplash && init.isReady) {
+      if (atSplash && init.canProceed) {
         return HarkRoutes.chat;
       }
-      if (!atSplash && !init.isReady) {
+      if (!atSplash && !init.canProceed) {
         return HarkRoutes.splash;
       }
       return null;

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -119,6 +119,12 @@ class SplashScreen extends ConsumerWidget {
                           message: init.failureMessage ?? 'Unknown error',
                           onRetry: () =>
                               ref.read(initProvider.notifier).retryAll(),
+                          isDegraded: init.isDegraded,
+                          onContinueDegraded: init.isDegraded
+                              ? () => ref
+                                    .read(initProvider.notifier)
+                                    .acceptDegraded()
+                              : null,
                         )
                       : Text(
                           init.isReady
@@ -331,10 +337,14 @@ class _FailurePanel extends StatelessWidget {
     super.key,
     required this.message,
     required this.onRetry,
+    this.isDegraded = false,
+    this.onContinueDegraded,
   });
 
   final String message;
   final VoidCallback onRetry;
+  final bool isDegraded;
+  final VoidCallback? onContinueDegraded;
 
   @override
   Widget build(BuildContext context) {
@@ -359,8 +369,25 @@ class _FailurePanel extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         Center(
-          child: FButton(onPress: onRetry, label: const Text('Retry')),
+          child: FButton(onPress: onRetry, child: const Text('Retry')),
         ),
+        if (isDegraded && onContinueDegraded != null) ...[
+          const SizedBox(height: 8),
+          Center(
+            child: FButton(
+              onPress: onContinueDegraded!,
+              variant: FButtonVariant.outline,
+              child: const Text('Continue in limited mode'),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Simple commands will work. Commands needing '
+            'parameter extraction will be unavailable.',
+            textAlign: TextAlign.center,
+            style: typography.xs.copyWith(color: colors.mutedForeground),
+          ),
+        ],
       ],
     );
   }

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -55,17 +55,26 @@ class SplashScreen extends ConsumerWidget {
                 Text(
                   'Voice assistant for your apps',
                   textAlign: TextAlign.center,
-                  style: typography.sm.copyWith(
-                    color: colors.mutedForeground,
-                  ),
+                  style: typography.sm.copyWith(color: colors.mutedForeground),
                 ),
                 const SizedBox(height: 40),
+                // Aggregate progress bar
+                if (!init.isReady && !init.hasFailure) ...[
+                  _ProgressBar(
+                    progress: init.aggregateProgress,
+                    indeterminate: init.aggregateProgress == null,
+                    isFailed: false,
+                  ),
+                  const SizedBox(height: 20),
+                ],
                 // Per-model progress
                 _ModelRow(
                   label: 'EmbeddingGemma',
                   stage: init.embedding.stage.name,
                   message: init.embedding.message,
                   progress: init.embedding.progress,
+                  receivedBytes: init.embedding.receivedBytes,
+                  totalBytes: init.embedding.totalBytes,
                   isReady: init.embedding.isReady,
                   isFailed: init.embedding.stage == EmbeddingStage.failed,
                   isBusy: init.embedding.isBusy,
@@ -77,8 +86,7 @@ class SplashScreen extends ConsumerWidget {
                   message: init.slotFilling.message,
                   progress: init.slotFilling.progress,
                   isReady: init.slotFilling.isReady,
-                  isFailed:
-                      init.slotFilling.stage == SlotFillingStage.failed,
+                  isFailed: init.slotFilling.stage == SlotFillingStage.failed,
                   isBusy: init.slotFilling.isBusy,
                 ),
                 const SizedBox(height: 14),
@@ -87,18 +95,42 @@ class SplashScreen extends ConsumerWidget {
                   error: init.registryError,
                 ),
                 const SizedBox(height: 32),
-                if (init.hasFailure)
-                  _FailurePanel(message: init.failureMessage ?? 'Unknown error')
-                else
-                  Text(
-                    init.isReady
-                        ? 'Ready.'
-                        : 'Preparing on-device models…',
-                    textAlign: TextAlign.center,
-                    style: typography.sm.copyWith(
-                      color: colors.mutedForeground,
+                // First-run explanation: shown when both models are downloading
+                // (no cache), so the user understands why hundreds of MB are
+                // being fetched before they can use the assistant.
+                if (init.embedding.stage == EmbeddingStage.downloading &&
+                    init.slotFilling.stage == SlotFillingStage.downloading)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    child: Text(
+                      'Downloading on-device AI models (~830 MB). '
+                      'This happens once — after this, Hark works offline.',
+                      textAlign: TextAlign.center,
+                      style: typography.xs.copyWith(
+                        color: colors.mutedForeground,
+                      ),
                     ),
                   ),
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 400),
+                  child: init.hasFailure
+                      ? _FailurePanel(
+                          key: const ValueKey('failure'),
+                          message: init.failureMessage ?? 'Unknown error',
+                          onRetry: () =>
+                              ref.read(initProvider.notifier).retryAll(),
+                        )
+                      : Text(
+                          init.isReady
+                              ? 'Ready.'
+                              : 'Preparing on-device models…',
+                          key: ValueKey(init.isReady ? 'ready' : 'preparing'),
+                          textAlign: TextAlign.center,
+                          style: typography.sm.copyWith(
+                            color: colors.mutedForeground,
+                          ),
+                        ),
+                ),
               ],
             ),
           ),
@@ -117,15 +149,26 @@ class _ModelRow extends StatelessWidget {
     required this.isReady,
     required this.isFailed,
     required this.isBusy,
+    this.receivedBytes,
+    this.totalBytes,
   });
 
   final String label;
   final String stage;
   final String message;
   final double? progress;
+  final int? receivedBytes;
+  final int? totalBytes;
   final bool isReady;
   final bool isFailed;
   final bool isBusy;
+
+  static String _formatBytes(int bytes) {
+    if (bytes < 1024 * 1024) {
+      return '${(bytes / 1024).toStringAsFixed(0)} KB';
+    }
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -134,21 +177,28 @@ class _ModelRow extends StatelessWidget {
     final accent = isFailed
         ? colors.destructive
         : isReady
-            ? colors.primary
-            : colors.mutedForeground;
+        ? colors.primary
+        : colors.mutedForeground;
+
+    // Build the sub-label: byte progress when downloading, otherwise message.
+    String? subLabel;
+    if (receivedBytes != null && totalBytes != null && totalBytes! > 0) {
+      subLabel =
+          '${_formatBytes(receivedBytes!)} / ${_formatBytes(totalBytes!)}';
+    } else if (!isReady && !isFailed && message.isNotEmpty) {
+      subLabel = message;
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Row(
           children: [
-            Container(
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 400),
               width: 8,
               height: 8,
-              decoration: BoxDecoration(
-                color: accent,
-                shape: BoxShape.circle,
-              ),
+              decoration: BoxDecoration(color: accent, shape: BoxShape.circle),
             ),
             const SizedBox(width: 10),
             Expanded(
@@ -160,13 +210,23 @@ class _ModelRow extends StatelessWidget {
                 ),
               ),
             ),
-            Text(
-              isFailed
-                  ? 'Failed'
-                  : isReady
-                      ? 'Ready'
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: Text(
+                isFailed
+                    ? 'Failed'
+                    : isReady
+                    ? 'Ready'
+                    : stage,
+                key: ValueKey(
+                  isFailed
+                      ? 'failed'
+                      : isReady
+                      ? 'ready'
                       : stage,
-              style: typography.xs.copyWith(color: accent),
+                ),
+                style: typography.xs.copyWith(color: accent),
+              ),
             ),
           ],
         ),
@@ -176,10 +236,10 @@ class _ModelRow extends StatelessWidget {
           indeterminate: isBusy && progress == null,
           isFailed: isFailed,
         ),
-        if (!isReady && !isFailed && message.isNotEmpty) ...[
+        if (subLabel != null) ...[
           const SizedBox(height: 4),
           Text(
-            message,
+            subLabel,
             style: typography.xs.copyWith(color: colors.mutedForeground),
           ),
         ],
@@ -202,18 +262,16 @@ class _RegistryRow extends StatelessWidget {
     final accent = failed
         ? colors.destructive
         : ready
-            ? colors.primary
-            : colors.mutedForeground;
+        ? colors.primary
+        : colors.mutedForeground;
 
     return Row(
       children: [
-        Container(
+        AnimatedContainer(
+          duration: const Duration(milliseconds: 400),
           width: 8,
           height: 8,
-          decoration: BoxDecoration(
-            color: accent,
-            shape: BoxShape.circle,
-          ),
+          decoration: BoxDecoration(color: accent, shape: BoxShape.circle),
         ),
         const SizedBox(width: 10),
         Expanded(
@@ -225,9 +283,19 @@ class _RegistryRow extends StatelessWidget {
             ),
           ),
         ),
-        Text(
-          failed ? 'Failed' : (ready ? 'Ready' : 'Scanning…'),
-          style: typography.xs.copyWith(color: accent),
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: Text(
+            failed ? 'Failed' : (ready ? 'Ready' : 'Scanning…'),
+            key: ValueKey(
+              failed
+                  ? 'failed'
+                  : ready
+                  ? 'ready'
+                  : 'scanning',
+            ),
+            style: typography.xs.copyWith(color: accent),
+          ),
         ),
       ],
     );
@@ -259,9 +327,14 @@ class _ProgressBar extends StatelessWidget {
 }
 
 class _FailurePanel extends StatelessWidget {
-  const _FailurePanel({required this.message});
+  const _FailurePanel({
+    super.key,
+    required this.message,
+    required this.onRetry,
+  });
 
   final String message;
+  final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -282,9 +355,11 @@ class _FailurePanel extends StatelessWidget {
         Text(
           message,
           textAlign: TextAlign.center,
-          style: typography.xs.copyWith(
-            color: colors.mutedForeground,
-          ),
+          style: typography.xs.copyWith(color: colors.mutedForeground),
+        ),
+        const SizedBox(height: 16),
+        Center(
+          child: FButton(onPress: onRetry, label: const Text('Retry')),
         ),
       ],
     );

--- a/lib/state/chat_notifier.dart
+++ b/lib/state/chat_notifier.dart
@@ -18,6 +18,7 @@ import '../services/stt_service.dart';
 import '../services/tts_service.dart';
 import 'chat_state.dart';
 import 'embedding_notifier.dart';
+import 'init_notifier.dart';
 import 'registry_provider.dart';
 import 'resolver_provider.dart';
 import 'services_providers.dart';
@@ -702,6 +703,11 @@ class ChatNotifier extends Notifier<ChatState> {
 
     // Then slot-filling model status.
     if (slotState.stage == SlotFillingStage.failed) {
+      // In degraded mode, show a warning but allow simple commands.
+      final init = ref.read(initProvider);
+      if (init.isDegraded && init.degradedAccepted) {
+        return 'Limited mode — simple commands only';
+      }
       return slotState.message;
     }
     if (slotState.isBusy) {

--- a/lib/state/embedding_notifier.dart
+++ b/lib/state/embedding_notifier.dart
@@ -37,8 +37,7 @@ class EmbeddingState {
 
   bool get isReady => stage == EmbeddingStage.ready && embedder != null;
   bool get isBusy =>
-      stage == EmbeddingStage.downloading ||
-      stage == EmbeddingStage.loading;
+      stage == EmbeddingStage.downloading || stage == EmbeddingStage.loading;
 
   EmbeddingState copyWith({
     EmbeddingStage? stage,
@@ -59,8 +58,7 @@ class EmbeddingState {
       receivedBytes: clearReceivedBytes
           ? null
           : (receivedBytes ?? this.receivedBytes),
-      totalBytes:
-          clearTotalBytes ? null : (totalBytes ?? this.totalBytes),
+      totalBytes: clearTotalBytes ? null : (totalBytes ?? this.totalBytes),
       embedder: clearEmbedder ? null : (embedder ?? this.embedder),
     );
   }
@@ -105,6 +103,16 @@ class EmbeddingNotifier extends Notifier<EmbeddingState> {
   /// True when the model has been fully loaded and is ready for inference.
   bool get isReady => state.embedder != null;
 
+  /// Reset and re-attempt initialization. Used by the splash retry button.
+  void retry() {
+    _initFuture = null;
+    state = const EmbeddingState(
+      stage: EmbeddingStage.idle,
+      message: 'Preparing EmbeddingGemma...',
+    );
+    _initFuture = _initialize();
+  }
+
   /// Embed a short query string. Applies the EmbeddingGemma query prompt
   /// template via [GemmaEmbedder.formatQuery] and returns an L2-normalized
   /// vector, matching the legacy service's exact behavior.
@@ -147,71 +155,101 @@ class EmbeddingNotifier extends Notifier<EmbeddingState> {
     final totalSw = Stopwatch()..start();
     try {
       debugPrint('EmbeddingNotifier: starting initialization...');
-      _setState(const EmbeddingState(
-        stage: EmbeddingStage.loading,
-        message: 'Initializing EmbeddingGemma runtime...',
-      ));
+      _setState(
+        const EmbeddingState(
+          stage: EmbeddingStage.loading,
+          message: 'Initializing EmbeddingGemma runtime...',
+        ),
+      );
 
       final runtimeSw = Stopwatch()..start();
       await initFlutterEmbedder();
       runtimeSw.stop();
-      unawaited(logger.logModelLoad(
-          'embedding.runtime_init', runtimeSw.elapsedMilliseconds));
+      unawaited(
+        logger.logModelLoad(
+          'embedding.runtime_init',
+          runtimeSw.elapsedMilliseconds,
+        ),
+      );
       if (_disposed) return;
       debugPrint('EmbeddingNotifier: runtime initialized OK');
 
       final managerSw = Stopwatch()..start();
       _modelManager ??= await ModelManager.withDefaultCacheDir();
       managerSw.stop();
-      unawaited(logger.logModelLoad(
-          'embedding.manager_init', managerSw.elapsedMilliseconds));
+      unawaited(
+        logger.logModelLoad(
+          'embedding.manager_init',
+          managerSw.elapsedMilliseconds,
+        ),
+      );
       if (_disposed) return;
 
       // Check if model is already downloaded
       final cacheSw = Stopwatch()..start();
       final localModel = await _modelManager!.getLocalModel(modelId);
       cacheSw.stop();
-      unawaited(logger.logModelLoad(
-          'embedding.cache_lookup', cacheSw.elapsedMilliseconds));
+      unawaited(
+        logger.logModelLoad(
+          'embedding.cache_lookup',
+          cacheSw.elapsedMilliseconds,
+        ),
+      );
       if (_disposed) return;
       if (localModel != null) {
         debugPrint(
-            'EmbeddingNotifier: model already cached, loading from disk...');
-        _setState(const EmbeddingState(
-          stage: EmbeddingStage.loading,
-          message: 'Loading EmbeddingGemma from cache...',
-        ));
+          'EmbeddingNotifier: model already cached, loading from disk...',
+        );
+        _setState(
+          const EmbeddingState(
+            stage: EmbeddingStage.loading,
+            message: 'Loading EmbeddingGemma from cache...',
+          ),
+        );
         final createSw = Stopwatch()..start();
         final embedder = GemmaEmbedder.create(
           modelPath: localModel.modelPath,
           tokenizerPath: localModel.tokenizerPath,
         );
         createSw.stop();
-        unawaited(logger.logModelLoad(
-            'embedding.model_create', createSw.elapsedMilliseconds));
+        unawaited(
+          logger.logModelLoad(
+            'embedding.model_create',
+            createSw.elapsedMilliseconds,
+          ),
+        );
         if (_disposed) return;
         debugPrint('EmbeddingNotifier: model loaded from cache!');
-        _setState(EmbeddingState(
-          stage: EmbeddingStage.ready,
-          message: 'EmbeddingGemma ready',
-          embedder: embedder,
-        ));
+        _setState(
+          EmbeddingState(
+            stage: EmbeddingStage.ready,
+            message: 'EmbeddingGemma ready',
+            embedder: embedder,
+          ),
+        );
         totalSw.stop();
-        unawaited(logger.logModelLoad(
-            'embedding.total', totalSw.elapsedMilliseconds,
-            extra: {'path': 'cache_hit'}));
+        unawaited(
+          logger.logModelLoad(
+            'embedding.total',
+            totalSw.elapsedMilliseconds,
+            extra: {'path': 'cache_hit'},
+          ),
+        );
         return;
       }
 
       // Not cached — download from HuggingFace
-      _setState(const EmbeddingState(
-        stage: EmbeddingStage.downloading,
-        message: 'Downloading EmbeddingGemma model...',
-        progress: 0,
-      ));
+      _setState(
+        const EmbeddingState(
+          stage: EmbeddingStage.downloading,
+          message: 'Downloading EmbeddingGemma model...',
+          progress: 0,
+        ),
+      );
 
       debugPrint(
-          'EmbeddingNotifier: starting model download from HuggingFace...');
+        'EmbeddingNotifier: starting model download from HuggingFace...',
+      );
       final embedder = await GemmaEmbedderFactory.fromHuggingFace(
         manager: _modelManager,
         onnxFile: 'onnx/model_q4.onnx',
@@ -225,40 +263,55 @@ class EmbeddingNotifier extends Notifier<EmbeddingState> {
                 '(${_formatBytes(received)} / ${_formatBytes(total)})',
               );
             }
-            _setState(EmbeddingState(
-              stage: EmbeddingStage.downloading,
-              message: 'Downloading EmbeddingGemma... '
-                  '${_formatBytes(received)} / ${_formatBytes(total)}',
-              progress: received / total,
-              receivedBytes: received,
-              totalBytes: total,
-            ));
+            _setState(
+              EmbeddingState(
+                stage: EmbeddingStage.downloading,
+                message:
+                    'Downloading EmbeddingGemma... '
+                    '${_formatBytes(received)} / ${_formatBytes(total)}',
+                progress: received / total,
+                receivedBytes: received,
+                totalBytes: total,
+              ),
+            );
           }
         },
       );
 
       if (_disposed) return;
       debugPrint('EmbeddingNotifier: model loaded successfully!');
-      _setState(EmbeddingState(
-        stage: EmbeddingStage.ready,
-        message: 'EmbeddingGemma ready',
-        embedder: embedder,
-      ));
+      _setState(
+        EmbeddingState(
+          stage: EmbeddingStage.ready,
+          message: 'EmbeddingGemma ready',
+          embedder: embedder,
+        ),
+      );
       totalSw.stop();
-      unawaited(logger.logModelLoad(
-          'embedding.total', totalSw.elapsedMilliseconds,
-          extra: {'path': 'downloaded'}));
+      unawaited(
+        logger.logModelLoad(
+          'embedding.total',
+          totalSw.elapsedMilliseconds,
+          extra: {'path': 'downloaded'},
+        ),
+      );
     } catch (error, stackTrace) {
       debugPrint('EmbeddingNotifier: failed to initialize: $error');
       debugPrint('EmbeddingNotifier: stackTrace: $stackTrace');
-      _setState(EmbeddingState(
-        stage: EmbeddingStage.failed,
-        message: 'EmbeddingGemma failed: $error',
-      ));
+      _setState(
+        EmbeddingState(
+          stage: EmbeddingStage.failed,
+          message: 'EmbeddingGemma failed: $error',
+        ),
+      );
       totalSw.stop();
-      unawaited(logger.logModelLoad(
-          'embedding.total', totalSw.elapsedMilliseconds,
-          extra: {'path': 'failed'}));
+      unawaited(
+        logger.logModelLoad(
+          'embedding.total',
+          totalSw.elapsedMilliseconds,
+          extra: {'path': 'failed'},
+        ),
+      );
       _initFuture = null;
     }
   }
@@ -287,7 +340,6 @@ class EmbeddingNotifier extends Notifier<EmbeddingState> {
 }
 
 /// Riverpod provider that exposes the [EmbeddingNotifier] and its state.
-final embeddingProvider =
-    NotifierProvider<EmbeddingNotifier, EmbeddingState>(
+final embeddingProvider = NotifierProvider<EmbeddingNotifier, EmbeddingState>(
   EmbeddingNotifier.new,
 );

--- a/lib/state/init_notifier.dart
+++ b/lib/state/init_notifier.dart
@@ -28,8 +28,7 @@ class InitState {
   final bool registryReady;
   final Object? registryError;
 
-  bool get isReady =>
-      embedding.isReady && slotFilling.isReady && registryReady;
+  bool get isReady => embedding.isReady && slotFilling.isReady && registryReady;
 
   bool get hasFailure =>
       embedding.stage == EmbeddingStage.failed ||
@@ -68,7 +67,8 @@ class InitState {
       return null;
     }
     final sum = values.fold<double>(0, (a, b) => a + b);
-    return sum / 2.0; // always average over both models, not just reporting ones
+    return sum /
+        2.0; // always average over both models, not just reporting ones
   }
 }
 
@@ -80,6 +80,24 @@ class InitNotifier extends Notifier<InitState> {
   final Stopwatch _buildSw = Stopwatch()..start();
   bool _allReadyLogged = false;
   bool _embeddingWarmupTriggered = false;
+
+  /// Retry all failed notifiers. Called from the splash retry button.
+  void retryAll() {
+    _allReadyLogged = false;
+    _embeddingWarmupTriggered = false;
+    _buildSw.reset();
+    _buildSw.start();
+
+    final embedding = ref.read(embeddingProvider);
+    final slotFilling = ref.read(slotFillingProvider);
+
+    if (embedding.stage == EmbeddingStage.failed) {
+      ref.read(embeddingProvider.notifier).retry();
+    }
+    if (slotFilling.stage == SlotFillingStage.failed) {
+      ref.read(slotFillingProvider.notifier).retry();
+    }
+  }
 
   @override
   InitState build() {
@@ -98,8 +116,9 @@ class InitNotifier extends Notifier<InitState> {
       _allReadyLogged = true;
       _buildSw.stop();
       final logger = ref.read(inferenceLoggerProvider);
-      unawaited(logger.logModelLoad(
-          'init.all_ready', _buildSw.elapsedMilliseconds));
+      unawaited(
+        logger.logModelLoad('init.all_ready', _buildSw.elapsedMilliseconds),
+      );
 
       // Phase 2b-2: pre-warm the action document embedding cache AFTER
       // all models are loaded — not during init. Running it during init
@@ -121,10 +140,16 @@ class InitNotifier extends Notifier<InitState> {
           final sw = Stopwatch()..start();
           await nluResolver.preWarmEmbeddings(actions);
           sw.stop();
-          debugPrint('HarkLoadPerf: embedding.cache_warmup '
-              '${sw.elapsedMilliseconds}ms');
-          unawaited(logger.logModelLoad(
-              'embedding.cache_warmup', sw.elapsedMilliseconds));
+          debugPrint(
+            'HarkLoadPerf: embedding.cache_warmup '
+            '${sw.elapsedMilliseconds}ms',
+          );
+          unawaited(
+            logger.logModelLoad(
+              'embedding.cache_warmup',
+              sw.elapsedMilliseconds,
+            ),
+          );
         }());
       }
     }
@@ -133,5 +158,6 @@ class InitNotifier extends Notifier<InitState> {
   }
 }
 
-final initProvider =
-    NotifierProvider<InitNotifier, InitState>(InitNotifier.new);
+final initProvider = NotifierProvider<InitNotifier, InitState>(
+  InitNotifier.new,
+);

--- a/lib/state/init_notifier.dart
+++ b/lib/state/init_notifier.dart
@@ -21,6 +21,7 @@ class InitState {
     required this.slotFilling,
     required this.registryReady,
     required this.registryError,
+    this.degradedAccepted = false,
   });
 
   final EmbeddingState embedding;
@@ -28,7 +29,21 @@ class InitState {
   final bool registryReady;
   final Object? registryError;
 
+  /// User accepted degraded mode via the splash "Continue in limited mode".
+  final bool degradedAccepted;
+
   bool get isReady => embedding.isReady && slotFilling.isReady && registryReady;
+
+  /// Embedding + registry work, but slot filler failed. The user can proceed
+  /// with keyword fast-path commands (zero-param actions). Parameterized
+  /// commands will fail gracefully with an informative message.
+  bool get isDegraded =>
+      embedding.isReady &&
+      registryReady &&
+      slotFilling.stage == SlotFillingStage.failed;
+
+  /// True when the router should allow navigation to the chat screen.
+  bool get canProceed => isReady || (isDegraded && degradedAccepted);
 
   bool get hasFailure =>
       embedding.stage == EmbeddingStage.failed ||
@@ -80,6 +95,14 @@ class InitNotifier extends Notifier<InitState> {
   final Stopwatch _buildSw = Stopwatch()..start();
   bool _allReadyLogged = false;
   bool _embeddingWarmupTriggered = false;
+  bool _degradedAccepted = false;
+
+  /// Accept degraded mode — proceed to chat without the slot filler.
+  void acceptDegraded() {
+    _degradedAccepted = true;
+    // Force rebuild so the router sees the updated canProceed.
+    ref.invalidateSelf();
+  }
 
   /// Retry all failed notifiers. Called from the splash retry button.
   void retryAll() {
@@ -110,9 +133,10 @@ class InitNotifier extends Notifier<InitState> {
       slotFilling: slotFilling,
       registryReady: registry.hasValue,
       registryError: registry.hasError ? registry.error : null,
+      degradedAccepted: _degradedAccepted,
     );
 
-    if (next.isReady && !_allReadyLogged) {
+    if ((next.isReady || next.canProceed) && !_allReadyLogged) {
       _allReadyLogged = true;
       _buildSw.stop();
       final logger = ref.read(inferenceLoggerProvider);

--- a/lib/state/slot_filling_notifier.dart
+++ b/lib/state/slot_filling_notifier.dart
@@ -93,6 +93,16 @@ class SlotFillingNotifier extends Notifier<SlotFillingState> {
   /// True when the model has been fully loaded and is ready for inference.
   bool get isReady => state.model != null;
 
+  /// Reset and re-attempt initialization. Used by the splash retry button.
+  void retry() {
+    _initFuture = null;
+    state = const SlotFillingState(
+      stage: SlotFillingStage.idle,
+      message: 'Preparing slot-filling model...',
+    );
+    _initFuture = _initialize();
+  }
+
   /// Extract parameters from a voice transcript given a matched action.
   ///
   /// Returns null if required parameters could not be extracted.
@@ -165,9 +175,7 @@ class SlotFillingNotifier extends Notifier<SlotFillingState> {
       }
 
       if (p.enumValues.isNotEmpty) {
-        paramDefs.writeln(
-          '  allowed values: ${p.enumValues.join(", ")}',
-        );
+        paramDefs.writeln('  allowed values: ${p.enumValues.join(", ")}');
       }
       if (p.minimum != null || p.maximum != null) {
         final bounds = <String>[];
@@ -321,53 +329,66 @@ class SlotFillingNotifier extends Notifier<SlotFillingState> {
     final totalSw = Stopwatch()..start();
     try {
       debugPrint('SlotFillingNotifier: starting initialization...');
-      _setState(const SlotFillingState(
-        stage: SlotFillingStage.loading,
-        message: 'Initializing slot-filling runtime...',
-      ));
+      _setState(
+        const SlotFillingState(
+          stage: SlotFillingStage.loading,
+          message: 'Initializing slot-filling runtime...',
+        ),
+      );
 
       final runtimeSw = Stopwatch()..start();
       await FlutterGemma.initialize();
       runtimeSw.stop();
-      unawaited(logger.logModelLoad(
-          'slot_filling.runtime_init', runtimeSw.elapsedMilliseconds));
+      unawaited(
+        logger.logModelLoad(
+          'slot_filling.runtime_init',
+          runtimeSw.elapsedMilliseconds,
+        ),
+      );
 
       // Check if model is already installed.
       final hasActiveSw = Stopwatch()..start();
       final hasActive = FlutterGemma.hasActiveModel();
       hasActiveSw.stop();
-      unawaited(logger.logModelLoad(
-          'slot_filling.has_active_check', hasActiveSw.elapsedMilliseconds));
+      unawaited(
+        logger.logModelLoad(
+          'slot_filling.has_active_check',
+          hasActiveSw.elapsedMilliseconds,
+        ),
+      );
       if (hasActive) {
-        debugPrint(
-            'SlotFillingNotifier: model already installed, loading...');
-        _setState(const SlotFillingState(
-          stage: SlotFillingStage.loading,
-          message: 'Loading Qwen3 from cache...',
-        ));
+        debugPrint('SlotFillingNotifier: model already installed, loading...');
+        _setState(
+          const SlotFillingState(
+            stage: SlotFillingStage.loading,
+            message: 'Loading Qwen3 from cache...',
+          ),
+        );
       } else {
         // Download from HuggingFace.
-        _setState(const SlotFillingState(
-          stage: SlotFillingStage.downloading,
-          message: 'Downloading Qwen3 0.6B...',
-          progress: 0,
-        ));
+        _setState(
+          const SlotFillingState(
+            stage: SlotFillingStage.downloading,
+            message: 'Downloading Qwen3 0.6B...',
+            progress: 0,
+          ),
+        );
 
         debugPrint('SlotFillingNotifier: downloading model from $modelUrl');
         await FlutterGemma.installModel(
           modelType: ModelType.qwen,
           fileType: ModelFileType.litertlm,
-        )
-            .fromNetwork(modelUrl)
-            .withProgress((pct) {
+        ).fromNetwork(modelUrl).withProgress((pct) {
           if (pct % 5 == 0) {
             debugPrint('SlotFillingNotifier: download $pct%');
           }
-          _setState(SlotFillingState(
-            stage: SlotFillingStage.downloading,
-            message: 'Downloading Qwen3 0.6B... $pct%',
-            progress: pct / 100,
-          ));
+          _setState(
+            SlotFillingState(
+              stage: SlotFillingStage.downloading,
+              message: 'Downloading Qwen3 0.6B... $pct%',
+              progress: pct / 100,
+            ),
+          );
         }).install();
       }
 
@@ -375,8 +396,12 @@ class SlotFillingNotifier extends Notifier<SlotFillingState> {
       final openSw = Stopwatch()..start();
       final model = await FlutterGemma.getActiveModel(maxTokens: 512);
       openSw.stop();
-      unawaited(logger.logModelLoad(
-          'slot_filling.model_open', openSw.elapsedMilliseconds));
+      unawaited(
+        logger.logModelLoad(
+          'slot_filling.model_open',
+          openSw.elapsedMilliseconds,
+        ),
+      );
 
       if (_disposed) {
         // A dispose happened while awaiting the model — don't leak it.
@@ -385,26 +410,38 @@ class SlotFillingNotifier extends Notifier<SlotFillingState> {
       }
 
       debugPrint('SlotFillingNotifier: model loaded successfully!');
-      _setState(SlotFillingState(
-        stage: SlotFillingStage.ready,
-        message: 'Qwen3 ready',
-        model: model,
-      ));
+      _setState(
+        SlotFillingState(
+          stage: SlotFillingStage.ready,
+          message: 'Qwen3 ready',
+          model: model,
+        ),
+      );
       totalSw.stop();
-      unawaited(logger.logModelLoad(
-          'slot_filling.total', totalSw.elapsedMilliseconds,
-          extra: {'path': hasActive ? 'cache_hit' : 'downloaded'}));
+      unawaited(
+        logger.logModelLoad(
+          'slot_filling.total',
+          totalSw.elapsedMilliseconds,
+          extra: {'path': hasActive ? 'cache_hit' : 'downloaded'},
+        ),
+      );
     } catch (error, stackTrace) {
       debugPrint('SlotFillingNotifier: failed to initialize: $error');
       debugPrint('SlotFillingNotifier: $stackTrace');
-      _setState(SlotFillingState(
-        stage: SlotFillingStage.failed,
-        message: 'Slot-filling model failed: $error',
-      ));
+      _setState(
+        SlotFillingState(
+          stage: SlotFillingStage.failed,
+          message: 'Slot-filling model failed: $error',
+        ),
+      );
       totalSw.stop();
-      unawaited(logger.logModelLoad(
-          'slot_filling.total', totalSw.elapsedMilliseconds,
-          extra: {'path': 'failed'}));
+      unawaited(
+        logger.logModelLoad(
+          'slot_filling.total',
+          totalSw.elapsedMilliseconds,
+          extra: {'path': 'failed'},
+        ),
+      );
       _initFuture = null;
     }
   }
@@ -431,5 +468,5 @@ class SlotFillingNotifier extends Notifier<SlotFillingState> {
 /// Riverpod provider that exposes the [SlotFillingNotifier] and its state.
 final slotFillingProvider =
     NotifierProvider<SlotFillingNotifier, SlotFillingState>(
-  SlotFillingNotifier.new,
-);
+      SlotFillingNotifier.new,
+    );


### PR DESCRIPTION
## Summary
- **Slice 3.1**: Retry button on failure panel — `retry()` on EmbeddingNotifier + SlotFillingNotifier, `retryAll()` on InitNotifier
- **Slice 3.2**: Byte-level download progress ("45.2 MB / 197.0 MB") + first-run explanation when both models are downloading
- **Slice 3.3**: Aggregate progress bar above per-model rows, animated dot indicators (AnimatedContainer), animated status labels (AnimatedSwitcher)
- **Slice 3.4**: Degraded mode — when embedder + registry succeed but slot filler fails, user can "Continue in limited mode". Router uses `canProceed` instead of `isReady`. Simple zero-param commands work; parameterized commands fail gracefully.

## Files changed
- `lib/screens/splash_screen.dart` — all UI changes
- `lib/state/init_notifier.dart` — retryAll, acceptDegraded, isDegraded, canProceed
- `lib/state/embedding_notifier.dart` — retry()
- `lib/state/slot_filling_notifier.dart` — retry()
- `lib/router/hark_router.dart` — canProceed gate
- `lib/state/chat_notifier.dart` — degraded mode status text

## Test plan
- [ ] Normal cached launch: aggregate bar + animated dots + status labels transition smoothly
- [ ] Clear app data + airplane mode: failure panel shows with Retry button
- [ ] Retry after reconnecting: models resume downloading
- [ ] First-run (cleared data, WiFi on): byte counts visible, first-run explanation text appears
- [ ] Degraded mode: if slot filler fails but embedder succeeds, "Continue in limited mode" button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)