### PR TITLE
feat: wake word robustness — FG service, overlay launch, lifecycle refresh

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <!-- Model backup persistence to Downloads/local-llm/ (pre-Android 10) -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
+    <!-- Wake word foreground service -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="Hark"
         android:name=".HarkApplication"
@@ -71,6 +75,13 @@
             </intent-filter>
         </service>
 
+        <!-- Wake word foreground service — keeps "Hey Hark" detection alive
+             and shows a persistent notification while listening. -->
+        <service
+            android:name=".WakeWordService"
+            android:foregroundServiceType="microphone"
+            android:exported="false" />
+
         <!-- Dedicated overlay Activity for the assistant panel.
              Translucent theme applied statically — no runtime switching. -->
         <activity
@@ -78,6 +89,8 @@
             android:theme="@style/OverlayTheme"
             android:launchMode="singleTop"
             android:taskAffinity=""
+            android:excludeFromRecents="true"
+            android:noHistory="true"
             android:exported="false"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true" />

--- a/android/app/src/main/kotlin/com/oacp/hark/HarkApplication.kt
+++ b/android/app/src/main/kotlin/com/oacp/hark/HarkApplication.kt
@@ -1,7 +1,16 @@
 package com.oacp.hark
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.service.voice.VoiceInteractionSession
 import android.util.Log
+import com.oacp.hark_platform.HarkResultFlutterApi
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.FlutterEngineCache
@@ -25,8 +34,12 @@ class HarkApplication : Application() {
     lateinit var engineGroup: FlutterEngineGroup
         private set
 
+    private val mainHandler = Handler(Looper.getMainLooper())
+
     override fun onCreate() {
         super.onCreate()
+
+        createNotificationChannels()
 
         engineGroup = FlutterEngineGroup(this)
 
@@ -35,6 +48,50 @@ class HarkApplication : Application() {
         FlutterEngineCache.getInstance().put(MAIN_ENGINE_ID, mainEngine)
 
         Log.i(TAG, "Main FlutterEngine created and cached")
+    }
+
+    private fun createNotificationChannels() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                WAKE_WORD_CHANNEL_ID,
+                "Wake Word Detection",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "Shows when Hark is listening for the wake word"
+            }
+            getSystemService(NotificationManager::class.java)
+                .createNotificationChannel(channel)
+        }
+    }
+
+    /**
+     * Called by [WakeWordService] when "Hey Hark" is detected.
+     * Launches the overlay via [VoiceInteractionService.showSession] (the
+     * system-sanctioned path, exempt from background activity restrictions)
+     * and notifies the main engine's Dart side via Pigeon.
+     */
+    fun onWakeWordDetected() {
+        Log.i(TAG, "Wake word detected — launching overlay")
+
+        // Launch overlay via VoiceInteractionService if available.
+        val vis = HarkVoiceInteractionService.instance
+        if (vis != null) {
+            vis.showSession(Bundle.EMPTY, VoiceInteractionSession.SHOW_WITH_ASSIST)
+        } else {
+            // Fallback: direct Activity launch (works when the app has a
+            // foreground service, giving it foreground-equivalent priority).
+            Log.w(TAG, "VIS not available, launching OverlayActivity directly")
+            val intent = Intent(this, OverlayActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+            startActivity(intent)
+        }
+
+        // Notify Dart so ChatNotifier knows the wake word fired.
+        val mainEngine = FlutterEngineCache.getInstance()
+            .get(MAIN_ENGINE_ID) ?: return
+        val api = HarkResultFlutterApi(mainEngine.dartExecutor.binaryMessenger)
+        mainHandler.post { api.onWakeWordDetected { } }
     }
 
     /**
@@ -73,5 +130,6 @@ class HarkApplication : Application() {
         private const val TAG = "HarkApplication"
         const val MAIN_ENGINE_ID = "main"
         const val OVERLAY_ENGINE_ID = "overlay"
+        const val WAKE_WORD_CHANNEL_ID = "wake_word"
     }
 }

--- a/android/app/src/main/kotlin/com/oacp/hark/HarkVoiceInteractionService.kt
+++ b/android/app/src/main/kotlin/com/oacp/hark/HarkVoiceInteractionService.kt
@@ -7,10 +7,20 @@ class HarkVoiceInteractionService : VoiceInteractionService() {
 
     override fun onReady() {
         super.onReady()
+        instance = this
         Log.i(TAG, "HarkVoiceInteractionService is ready")
+    }
+
+    override fun onDestroy() {
+        instance = null
+        super.onDestroy()
     }
 
     companion object {
         private const val TAG = "HarkVIS"
+
+        /** Live reference used by [HarkApplication.onWakeWordDetected] to launch the overlay. */
+        var instance: HarkVoiceInteractionService? = null
+            private set
     }
 }

--- a/android/app/src/main/kotlin/com/oacp/hark/WakeWordService.kt
+++ b/android/app/src/main/kotlin/com/oacp/hark/WakeWordService.kt
@@ -1,0 +1,128 @@
+package com.oacp.hark
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.oacp.hark_platform.HarkPlatformPlugin
+import com.oacp.hark_platform.WakeWordDetector
+
+/**
+ * Foreground service that keeps wake word detection alive and visible.
+ *
+ * The service owns a [WakeWordDetector] and shows a persistent notification
+ * while listening. On detection it pauses the detector (releasing the mic
+ * for STT) and delegates to [HarkApplication.onWakeWordDetected].
+ *
+ * Controlled via intent actions from [HarkPlatformPlugin]:
+ * - [ACTION_START] — start detection + foreground notification
+ * - [ACTION_STOP]  — stop detection + remove notification + stop service
+ * - [ACTION_PAUSE] — pause detector (release mic for STT)
+ * - [ACTION_RESUME] — resume detector (re-acquire mic after STT)
+ */
+class WakeWordService : Service() {
+
+    private var detector: WakeWordDetector? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> {
+                if (detector?.isRunning == true) {
+                    Log.d(TAG, "Already running, ignoring START")
+                    return START_STICKY
+                }
+                startForeground(
+                    NOTIFICATION_ID,
+                    buildNotification(),
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+                )
+                startDetection()
+                HarkPlatformPlugin.wakeWordRunning = true
+                Log.i(TAG, "Wake word service started")
+            }
+            ACTION_STOP -> {
+                detector?.release()
+                detector = null
+                HarkPlatformPlugin.wakeWordRunning = false
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+                Log.i(TAG, "Wake word service stopped")
+            }
+            ACTION_PAUSE -> {
+                detector?.pause()
+                Log.d(TAG, "Detection paused")
+            }
+            ACTION_RESUME -> {
+                detector?.resume()
+                Log.d(TAG, "Detection resumed")
+            }
+            null -> {
+                // Service restarted by system (START_STICKY with null intent).
+                startForeground(
+                    NOTIFICATION_ID,
+                    buildNotification(),
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
+                )
+                startDetection()
+                HarkPlatformPlugin.wakeWordRunning = true
+                Log.i(TAG, "Wake word service restarted by system")
+            }
+        }
+        return START_STICKY
+    }
+
+    private fun startDetection() {
+        detector = WakeWordDetector(this).apply {
+            start(
+                listener = { onWakeWordDetected() },
+                modelPath = "wakeword/hey_harkh.onnx",
+                threshold = 0.3f,
+            )
+        }
+    }
+
+    private fun onWakeWordDetected() {
+        // Release mic immediately so STT can use it when the overlay opens.
+        detector?.pause()
+        (application as HarkApplication).onWakeWordDetected()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        detector?.release()
+        detector = null
+        HarkPlatformPlugin.wakeWordRunning = false
+        Log.i(TAG, "Wake word service destroyed")
+        super.onDestroy()
+    }
+
+    private fun buildNotification(): Notification {
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Builder(this, HarkApplication.WAKE_WORD_CHANNEL_ID)
+            .setContentTitle("Hark")
+            .setContentText("Listening for \"Hey Hark\"")
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .build()
+    }
+
+    companion object {
+        private const val TAG = "WakeWordService"
+        const val ACTION_START = "com.oacp.hark.WAKE_WORD_START"
+        const val ACTION_STOP = "com.oacp.hark.WAKE_WORD_STOP"
+        const val ACTION_PAUSE = "com.oacp.hark.WAKE_WORD_PAUSE"
+        const val ACTION_RESUME = "com.oacp.hark.WAKE_WORD_RESUME"
+        const val NOTIFICATION_ID = 1001
+    }
+}

--- a/android/app/src/main/kotlin/com/oacp/hark/WakeWordService.kt
+++ b/android/app/src/main/kotlin/com/oacp/hark/WakeWordService.kt
@@ -51,6 +51,9 @@ class WakeWordService : Service() {
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
                 Log.i(TAG, "Wake word service stopped")
+                // Return NOT_STICKY so Android doesn't auto-restart us
+                // after the user explicitly stopped.
+                return START_NOT_STICKY
             }
             ACTION_PAUSE -> {
                 detector?.pause()
@@ -102,17 +105,29 @@ class WakeWordService : Service() {
     }
 
     private fun buildNotification(): Notification {
-        val pendingIntent = PendingIntent.getActivity(
+        val contentPendingIntent = PendingIntent.getActivity(
             this,
             0,
             Intent(this, MainActivity::class.java),
             PendingIntent.FLAG_IMMUTABLE,
         )
+        // "Stop" action: sends ACTION_STOP to ourselves, which releases
+        // the mic and removes the notification.
+        val stopIntent = Intent(this, WakeWordService::class.java).apply {
+            action = ACTION_STOP
+        }
+        val stopPendingIntent = PendingIntent.getService(
+            this,
+            1,
+            stopIntent,
+            PendingIntent.FLAG_IMMUTABLE,
+        )
         return NotificationCompat.Builder(this, HarkApplication.WAKE_WORD_CHANNEL_ID)
             .setContentTitle("Hark")
             .setContentText("Listening for \"Hey Hark\"")
-            .setSmallIcon(R.mipmap.ic_launcher)
-            .setContentIntent(pendingIntent)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentIntent(contentPendingIntent)
+            .addAction(0, "Stop", stopPendingIntent)
             .setOngoing(true)
             .build()
     }

--- a/android/app/src/main/res/drawable/ic_notification.xml
+++ b/android/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!--
+        Hark robot silhouette — approximated from the hark_logo mascot.
+        White-on-transparent so Android small-icon tinting works.
+        evenOdd fill rule makes eye + antenna-base circles cut out of the head.
+    -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M11,2 a1.2,1.2 0 1,1 2.4,0 a1.2,1.2 0 1,1 -2.4,0 Z
+                          M11.4,4.4 h1.2 v2.6 h-1.2 Z
+                          M6.5,7 h11 a2.5,2.5 0 0,1 2.5,2.5 v8 a2.5,2.5 0 0,1 -2.5,2.5 h-11 a2.5,2.5 0 0,1 -2.5,-2.5 v-8 a2.5,2.5 0 0,1 2.5,-2.5 Z
+                          M8.5,12.5 a1.1,1.1 0 1,1 2.2,0 a1.1,1.1 0 1,1 -2.2,0 Z
+                          M13.3,12.5 a1.1,1.1 0 1,1 2.2,0 a1.1,1.1 0 1,1 -2.2,0 Z"/>
+</vector>

--- a/lib/state/chat_notifier.dart
+++ b/lib/state/chat_notifier.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hark_platform/hark_platform.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -52,6 +52,7 @@ class ChatNotifier extends Notifier<ChatState> {
   // Transient state that doesn't belong in [ChatState].
   StreamSubscription<OacpResult>? _resultSubscription;
   StreamSubscription<void>? _wakeWordSubscription;
+  AppLifecycleListener? _lifecycleListener;
   Timer? _restartTimer;
   int _messageCounter = 0;
 
@@ -99,6 +100,7 @@ class ChatNotifier extends Notifier<ChatState> {
       _restartTimer?.cancel();
       _resultSubscription?.cancel();
       _wakeWordSubscription?.cancel();
+      _lifecycleListener?.dispose();
       // Do NOT dispose STT/TTS/etc — they are owned by their own providers.
     });
 
@@ -122,8 +124,10 @@ class ChatNotifier extends Notifier<ChatState> {
 
       _resultSubscription = _resultService.results.listen(_onOacpResult);
       _wakeWordSubscription = _resultService.wakeWordDetections.listen((_) {
-        debugPrint('ChatNotifier: wake word detected, auto-starting mic');
-        onMicPressed();
+        debugPrint('ChatNotifier: wake word detected — overlay launching');
+        // Overlay launch is handled natively (showSession → HarkSession →
+        // OverlayActivity). The overlay's onOverlayOpened callback triggers
+        // mic start via the bridge. No onMicPressed() here.
       });
 
       final sttInit = await _sttService.initialize();
@@ -133,6 +137,14 @@ class ChatNotifier extends Notifier<ChatState> {
 
       await _checkDefaultAssistant();
 
+      // Request notification permission so the wake word foreground
+      // service can show its "Listening for Hey Hark" notification.
+      // Required on Android 13+; silently no-ops on older versions.
+      final notifStatus = await Permission.notification.status;
+      if (!notifStatus.isGranted) {
+        await Permission.notification.request();
+      }
+
       // Start wake word detection after init completes.
       try {
         _commonApi.startWakeWordService();
@@ -140,6 +152,10 @@ class ChatNotifier extends Notifier<ChatState> {
       } catch (e) {
         debugPrint('ChatNotifier: wake word start failed: $e');
       }
+
+      // Refresh capabilities when the app returns to the foreground so
+      // installs, uninstalls, and manifest changes are picked up.
+      _lifecycleListener = AppLifecycleListener(onResume: _onAppResumed);
 
       // Success: drop any prior init error so the UI can clear its banner.
       state = state.copyWith(
@@ -604,6 +620,28 @@ class ChatNotifier extends Notifier<ChatState> {
   Future<void> _checkDefaultAssistant() async {
     final result = await _commonApi.isDefaultAssistant();
     state = state.copyWith(isDefaultAssistant: result);
+  }
+
+  /// Re-discovers OACP capabilities when the app resumes from background.
+  /// Catches app installs, uninstalls, and manifest changes.
+  Future<void> _onAppResumed() async {
+    if (_registry == null || state.isInitializing) return;
+
+    debugPrint('ChatNotifier: app resumed, refreshing capabilities');
+    ref.invalidate(capabilityRegistryProvider);
+    try {
+      final registry = await ref.read(capabilityRegistryProvider.future);
+      _registry = registry;
+
+      if (registry.hasAvailableActions) {
+        final nluResolver = ref.read(nluResolverProvider);
+        await nluResolver.preWarmEmbeddings(registry.actions);
+      }
+
+      state = state.copyWith(statusText: _idleStatusText());
+    } catch (e) {
+      debugPrint('ChatNotifier: capability refresh failed: $e');
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/hark_platform/android/src/main/kotlin/com/oacp/hark_platform/HarkPlatformPlugin.kt
+++ b/packages/hark_platform/android/src/main/kotlin/com/oacp/hark_platform/HarkPlatformPlugin.kt
@@ -15,7 +15,6 @@ import android.os.Looper
 import android.provider.Settings
 import android.util.Log
 import io.flutter.embedding.engine.plugins.FlutterPlugin
-import io.flutter.plugin.common.BinaryMessenger
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
@@ -58,8 +57,6 @@ class HarkPlatformPlugin : FlutterPlugin, HarkCommonApi {
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         HarkCommonApi.setUp(binding.binaryMessenger, null)
-        wakeWordDetector?.release()
-        wakeWordDetector = null
         resultReceiver?.unregister()
         resultReceiver = null
         resultFlutterApi = null
@@ -376,45 +373,35 @@ class HarkPlatformPlugin : FlutterPlugin, HarkCommonApi {
     }
 
     // ── HarkCommonApi: wake word detection ─────────────────────
+    //
+    // Wake word detection runs in a foreground Service (WakeWordService)
+    // in the main app module. This plugin acts as a control interface,
+    // sending intent actions to start/stop/pause/resume the service.
 
-    private var wakeWordDetector: WakeWordDetector? = null
-
-    // TODO: startWakeWordService silently fails if context is null (detached
-    // engine). Consider returning a Result or throwing so Dart knows it failed.
     override fun startWakeWordService() {
         val ctx = context ?: return
-        if (wakeWordDetector?.isRunning == true) return
-
-        val detector = WakeWordDetector(ctx)
-        detector.start(
-            listener = WakeWordDetector.Listener {
-                // Notify Dart that wake word was detected.
-                resultFlutterApi?.onWakeWordDetected { }
-            },
-            modelPath = "wakeword/hey_harkh.onnx",
-            threshold = 0.3f,
-        )
-        wakeWordDetector = detector
-        Log.i(TAG, "Wake word service started")
+        ctx.startForegroundService(wakeWordIntent(ctx, "com.oacp.hark.WAKE_WORD_START"))
     }
 
     override fun stopWakeWordService() {
-        wakeWordDetector?.release()
-        wakeWordDetector = null
-        Log.i(TAG, "Wake word service stopped")
+        val ctx = context ?: return
+        ctx.startService(wakeWordIntent(ctx, "com.oacp.hark.WAKE_WORD_STOP"))
     }
 
-    override fun isWakeWordRunning(): Boolean {
-        return wakeWordDetector?.isRunning == true
-    }
+    override fun isWakeWordRunning(): Boolean = wakeWordRunning
 
     override fun setWakeWordPaused(paused: Boolean) {
-        if (paused) {
-            wakeWordDetector?.pause()
-        } else {
-            wakeWordDetector?.resume()
-        }
+        val ctx = context ?: return
+        val action = if (paused) "com.oacp.hark.WAKE_WORD_PAUSE"
+                     else "com.oacp.hark.WAKE_WORD_RESUME"
+        ctx.startService(wakeWordIntent(ctx, action))
     }
+
+    private fun wakeWordIntent(ctx: Context, action: String): Intent =
+        Intent().apply {
+            setClassName(ctx, "com.oacp.hark.WakeWordService")
+            this.action = action
+        }
 
     // ── OACP result receiver (BroadcastReceiver → FlutterApi) ────
 
@@ -469,5 +456,13 @@ class HarkPlatformPlugin : FlutterPlugin, HarkCommonApi {
 
     companion object {
         private const val TAG = "HarkPlatform"
+
+        /**
+         * Set by [WakeWordService] in the app module to report running state.
+         * Avoids cross-module class references while staying in the same process.
+         */
+        @Volatile
+        @JvmStatic
+        var wakeWordRunning: Boolean = false
     }
 }


### PR DESCRIPTION
## Summary

Four robustness improvements to the wake word feature that shipped in #18:

- **Wake word foreground service.** `WakeWordService` now owns the `WakeWordDetector` with `FOREGROUND_SERVICE_TYPE_MICROPHONE`, a persistent notification, and `START_STICKY` — hardens against OEM kill behavior and makes the "mic is on" state visible to the user.
- **Wake word → overlay launch.** Detection now calls `VoiceInteractionService.showSession()` (the system-sanctioned background-launch path) so saying "Hey Hark" from any screen opens the assistant panel. Previously it only started the mic on the main engine with no UI.
- **Recents cleanup.** `OverlayActivity` gains `excludeFromRecents` + `noHistory` so it no longer shows up as a duplicate task entry in Recents.
- **Capability freshness.** `AppLifecycleListener` in `ChatNotifier` invalidates `capabilityRegistryProvider` and re-warms embeddings on app resume, so uninstalled OACP apps drop out of the registry without a restart.

Also included:
- Runtime `POST_NOTIFICATIONS` request on Android 13+ so the FG notification is visible.
- Monochrome `ic_notification` vector drawable (Hark robot silhouette) — required by Android for notification small icons.
- "Stop" action on the notification so users can release the mic without relaunching the app. Returns `START_NOT_STICKY` on explicit stop so Android doesn't auto-restart.

## Test plan

- [x] `flutter analyze` clean
- [x] Swipe assist gesture → only one Hark task in Recents
- [x] `adb shell dumpsys activity services | grep WakeWord` → `isForeground=true`, `types=microphone`
- [x] Persistent notification visible in status bar with robot silhouette small icon
- [x] "Hey Hark" from background → overlay appears, mic auto-starts (verified via `adb logcat`: `WakeWordDetector → HarkApplication → HarkSession → OverlayActivity`)
- [x] "Hey Hark" back-to-back → `onNewIntent` refreshes overlay session
- [x] Detection paused during STT, resumed after
- [x] App resume refresh fires (`adb logcat | grep "app resumed, refreshing"`)
- [x] Notification "Stop" action releases mic and removes notification