### PR TITLE
feat: Settings screen (permissions, wake word toggle, models, about)

### DIFF
--- a/lib/router/hark_router.dart
+++ b/lib/router/hark_router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../screens/available_actions_screen.dart';
 import '../screens/chat_screen.dart';
+import '../screens/settings_screen.dart';
 import '../screens/splash_screen.dart';
 import '../state/init_notifier.dart';
 
@@ -15,6 +16,7 @@ class HarkRoutes {
   static const splash = '/';
   static const chat = '/chat';
   static const actions = '/actions';
+  static const settings = '/settings';
 }
 
 /// Provides the app's singleton [GoRouter].
@@ -65,6 +67,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         path: HarkRoutes.actions,
         name: 'actions',
         builder: (_, _) => const AvailableActionsScreen(),
+      ),
+      GoRoute(
+        path: HarkRoutes.settings,
+        name: 'settings',
+        builder: (_, _) => const SettingsScreen(),
       ),
     ],
   );

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -66,6 +66,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             variant: FButtonVariant.ghost,
             child: const Icon(FIcons.listChecks),
           ),
+          FButton.icon(
+            onPress: () => context.push(HarkRoutes.settings),
+            variant: FButtonVariant.ghost,
+            child: const Icon(FIcons.settings),
+          ),
         ],
       ),
       child: Column(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,447 @@
+import 'package:flutter/material.dart' show Switch;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart';
+import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../state/chat_notifier.dart';
+import '../state/settings_notifier.dart';
+
+/// User-facing settings surface.
+///
+/// Four sections: permissions, wake word, models, about. Permissions show
+/// live status and expose a button to request or open system settings for
+/// anything that isn't granted. The wake word section toggles the
+/// foreground service via [settingsProvider]. Models are read-only info
+/// rows. About shows version + GitHub link.
+class SettingsScreen extends ConsumerStatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends ConsumerState<SettingsScreen>
+    with WidgetsBindingObserver {
+  PermissionStatus _micStatus = PermissionStatus.denied;
+  PermissionStatus _notifStatus = PermissionStatus.denied;
+  PackageInfo? _packageInfo;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _refreshAll();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _refreshAll();
+  }
+
+  Future<void> _refreshAll() async {
+    final mic = await Permission.microphone.status;
+    final notif = await Permission.notification.status;
+    final info = await PackageInfo.fromPlatform();
+    if (!mounted) return;
+    setState(() {
+      _micStatus = mic;
+      _notifStatus = notif;
+      _packageInfo = info;
+    });
+  }
+
+  Future<void> _requestMic() async {
+    final result = await Permission.microphone.request();
+    if (result.isPermanentlyDenied) {
+      await openAppSettings();
+    }
+    _refreshAll();
+  }
+
+  Future<void> _requestNotif() async {
+    final result = await Permission.notification.request();
+    if (result.isPermanentlyDenied) {
+      await openAppSettings();
+    }
+    _refreshAll();
+  }
+
+  Future<void> _openAssistantSettings() async {
+    await ref.read(chatProvider.notifier).openAssistantSettings();
+  }
+
+  Future<void> _openGitHub() async {
+    final uri = Uri.parse('https://github.com/OpenAppCapabilityProtocol/hark');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final chat = ref.watch(chatProvider);
+    final settings = ref.watch(settingsProvider);
+
+    return FScaffold(
+      header: FHeader.nested(
+        title: const Text('Settings'),
+        prefixes: [
+          FButton.icon(
+            onPress: () => context.pop(),
+            variant: FButtonVariant.ghost,
+            child: const Icon(FIcons.arrowLeft),
+          ),
+        ],
+      ),
+      child: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        children: [
+          _SectionHeader('Permissions'),
+          _PermissionRow(
+            icon: FIcons.mic,
+            label: 'Microphone',
+            description: 'Required to listen to voice commands.',
+            status: _micStatus,
+            onFix: _requestMic,
+          ),
+          _PermissionRow(
+            icon: FIcons.bell,
+            label: 'Notifications',
+            description:
+                'Lets the wake word foreground service show its status.',
+            status: _notifStatus,
+            onFix: _requestNotif,
+          ),
+          _AssistantRoleRow(
+            isDefault: chat.isDefaultAssistant,
+            onFix: _openAssistantSettings,
+          ),
+
+          _SectionHeader('Wake word'),
+          _WakeWordToggle(
+            state: settings,
+            onChanged: (value) =>
+                ref.read(settingsProvider.notifier).setWakeWordEnabled(value),
+          ),
+          const _InfoRow(
+            icon: FIcons.file,
+            label: 'Model',
+            value: 'hey_harkh.onnx · 201 KB',
+          ),
+          const _InfoRow(
+            icon: FIcons.gauge,
+            label: 'Threshold',
+            value: '0.3 (cooldown 1500 ms)',
+          ),
+
+          _SectionHeader('Models'),
+          const _InfoRow(
+            icon: FIcons.brain,
+            label: 'Intent selection',
+            value: 'EmbeddingGemma 308M',
+          ),
+          const _InfoRow(
+            icon: FIcons.wrench,
+            label: 'Slot filling',
+            value: 'Qwen3 0.6B',
+          ),
+
+          _SectionHeader('About'),
+          _InfoRow(
+            icon: FIcons.info,
+            label: 'Version',
+            value: _packageInfo == null
+                ? '—'
+                : '${_packageInfo!.version}+${_packageInfo!.buildNumber}',
+          ),
+          const _InfoRow(
+            icon: FIcons.shield,
+            label: 'Protocol',
+            value: 'OACP v0.3',
+          ),
+          _ActionRow(
+            icon: FIcons.github,
+            label: 'GitHub',
+            onTap: _openGitHub,
+          ),
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+      child: Text(
+        title.toUpperCase(),
+        style: typography.xs.copyWith(
+          color: colors.mutedForeground,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.8,
+        ),
+      ),
+    );
+  }
+}
+
+class _PermissionRow extends StatelessWidget {
+  const _PermissionRow({
+    required this.icon,
+    required this.label,
+    required this.description,
+    required this.status,
+    required this.onFix,
+  });
+
+  final IconData icon;
+  final String label;
+  final String description;
+  final PermissionStatus status;
+  final Future<void> Function() onFix;
+
+  @override
+  Widget build(BuildContext context) {
+    final granted = status.isGranted;
+    return _Row(
+      icon: icon,
+      label: label,
+      description: description,
+      trailing: granted
+          ? _StatusPill(text: 'Granted', ok: true)
+          : FButton(
+              onPress: onFix,
+              variant: FButtonVariant.secondary,
+              child: Text(status.isPermanentlyDenied ? 'Open' : 'Grant'),
+            ),
+    );
+  }
+}
+
+class _AssistantRoleRow extends StatelessWidget {
+  const _AssistantRoleRow({required this.isDefault, required this.onFix});
+
+  final bool isDefault;
+  final Future<void> Function() onFix;
+
+  @override
+  Widget build(BuildContext context) {
+    return _Row(
+      icon: FIcons.wand,
+      label: 'Default assistant',
+      description:
+          'Required for long-press Home and background overlay launch.',
+      trailing: isDefault
+          ? _StatusPill(text: 'Active', ok: true)
+          : FButton(
+              onPress: onFix,
+              variant: FButtonVariant.secondary,
+              child: const Text('Set'),
+            ),
+    );
+  }
+}
+
+class _WakeWordToggle extends StatelessWidget {
+  const _WakeWordToggle({required this.state, required this.onChanged});
+
+  final AsyncValue<SettingsState> state;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final current = switch (state) {
+      AsyncData(:final value) => value,
+      _ => null,
+    };
+    final enabled = current?.wakeWordEnabled ?? true;
+    return _Row(
+      icon: FIcons.ear,
+      label: '"Hey Hark" detection',
+      description: enabled
+          ? 'Listening with an on-device 201 KB model.'
+          : 'Wake word is off. Use the mic button instead.',
+      trailing: state.isLoading
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: FCircularProgress(size: FCircularProgressSizeVariant.sm),
+            )
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  enabled ? 'On' : 'Off',
+                  style: context.theme.typography.sm.copyWith(
+                    color: enabled ? colors.primary : colors.mutedForeground,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Switch(
+                  value: enabled,
+                  onChanged: onChanged,
+                  activeThumbColor: colors.primary,
+                ),
+              ],
+            ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    return _Row(
+      icon: icon,
+      label: label,
+      trailing: Text(
+        value,
+        style: typography.sm.copyWith(color: colors.mutedForeground),
+      ),
+    );
+  }
+}
+
+class _ActionRow extends StatelessWidget {
+  const _ActionRow({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final Future<void> Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    return FTappable(
+      onPress: onTap,
+      child: _Row(
+        icon: icon,
+        label: label,
+        trailing: Icon(
+          FIcons.chevronRight,
+          size: 16,
+          color: colors.mutedForeground,
+        ),
+      ),
+    );
+  }
+}
+
+class _Row extends StatelessWidget {
+  const _Row({
+    required this.icon,
+    required this.label,
+    this.description,
+    required this.trailing,
+  });
+
+  final IconData icon;
+  final String label;
+  final String? description;
+  final Widget trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(icon, size: 20, color: colors.mutedForeground),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: typography.sm.copyWith(
+                    color: colors.foreground,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                if (description != null) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    description!,
+                    style: typography.xs.copyWith(
+                      color: colors.mutedForeground,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          trailing,
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusPill extends StatelessWidget {
+  const _StatusPill({required this.text, required this.ok});
+
+  final String text;
+  final bool ok;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final bg = ok
+        ? colors.primary.withValues(alpha: 0.15)
+        : colors.destructive.withValues(alpha: 0.15);
+    final fg = ok ? colors.primary : colors.destructive;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        text,
+        style: typography.xs.copyWith(color: fg, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -77,6 +77,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
   }
 
   Future<void> _openAssistantSettings() async {
+    // TODO: move openAssistantSettings() off ChatNotifier into a dedicated
+    // platform notifier so the Settings screen doesn't depend on chat state
+    // just to reach a system intent.
     await ref.read(chatProvider.notifier).openAssistantSettings();
   }
 
@@ -145,6 +148,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
           ),
 
           _SectionHeader('Models'),
+          // TODO: source model names + sizes from embeddingProvider /
+          // slotFillingProvider so they don't drift if the defaults change.
           const _InfoRow(
             icon: FIcons.brain,
             label: 'Intent selection',

--- a/lib/state/chat_notifier.dart
+++ b/lib/state/chat_notifier.dart
@@ -22,6 +22,7 @@ import 'init_notifier.dart';
 import 'registry_provider.dart';
 import 'resolver_provider.dart';
 import 'services_providers.dart';
+import 'settings_notifier.dart';
 import 'slot_filling_notifier.dart';
 
 /// Owns all chat business logic for the Hark voice assistant screen.
@@ -151,10 +152,16 @@ class ChatNotifier extends Notifier<ChatState> {
         await Permission.notification.request();
       }
 
-      // Start wake word detection after init completes.
+      // Start wake word detection after init completes, but only if the
+      // user hasn't disabled it from the Settings screen.
       try {
-        _commonApi.startWakeWordService();
-        debugPrint('ChatNotifier: wake word detection started');
+        final wakeWordEnabled = await readWakeWordEnabledPref();
+        if (wakeWordEnabled) {
+          _commonApi.startWakeWordService();
+          debugPrint('ChatNotifier: wake word detection started');
+        } else {
+          debugPrint('ChatNotifier: wake word disabled by user preference');
+        }
       } catch (e) {
         debugPrint('ChatNotifier: wake word start failed: $e');
       }

--- a/lib/state/settings_notifier.dart
+++ b/lib/state/settings_notifier.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hark_platform/hark_platform.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _kWakeWordEnabled = 'wake_word_enabled';
+
+/// User-tunable settings backed by [SharedPreferences].
+///
+/// Currently only tracks the wake word on/off preference. Built as an
+/// [AsyncNotifier] so the UI can `watch` it and react to the persisted value
+/// once it loads — the initial `null` state is handled by the Settings screen
+/// with a loading indicator.
+class SettingsNotifier extends AsyncNotifier<SettingsState> {
+  final _commonApi = HarkCommonApi();
+
+  @override
+  Future<SettingsState> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    final wakeWordEnabled = prefs.getBool(_kWakeWordEnabled) ?? true;
+    return SettingsState(wakeWordEnabled: wakeWordEnabled);
+  }
+
+  /// Toggle wake word detection. Persists immediately and starts/stops the
+  /// foreground service.
+  Future<void> setWakeWordEnabled(bool enabled) async {
+    final prev = switch (state) {
+      AsyncData(:final value) => value,
+      _ => null,
+    };
+    state = AsyncData(SettingsState(wakeWordEnabled: enabled));
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_kWakeWordEnabled, enabled);
+      if (enabled) {
+        _commonApi.startWakeWordService();
+      } else {
+        _commonApi.stopWakeWordService();
+      }
+    } catch (e) {
+      debugPrint('SettingsNotifier: wake word toggle failed: $e');
+      if (prev != null) state = AsyncData(prev);
+    }
+  }
+}
+
+@immutable
+class SettingsState {
+  const SettingsState({required this.wakeWordEnabled});
+
+  final bool wakeWordEnabled;
+}
+
+final settingsProvider =
+    AsyncNotifierProvider<SettingsNotifier, SettingsState>(SettingsNotifier.new);
+
+/// Read the persisted wake word preference without spinning up a notifier
+/// dependency. Used by [ChatNotifier] at init time to decide whether to
+/// start the wake word service at all.
+Future<bool> readWakeWordEnabledPref() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getBool(_kWakeWordEnabled) ?? true;
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_gemma/flutter_gemma_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_gemma_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterGemmaPlugin");
   flutter_gemma_plugin_register_with_registrar(flutter_gemma_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_gemma
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,16 @@ import Foundation
 
 import flutter_gemma
 import flutter_tts
+import package_info_plus
 import shared_preferences_foundation
 import speech_to_text
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterGemmaPlugin.register(with: registry.registrar(forPlugin: "FlutterGemmaPlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SpeechToTextPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -524,6 +524,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -913,6 +929,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -969,6 +1049,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   flutter_riverpod: ^3.3.1
   go_router: ^17.2.0
   installed_apps: ^2.1.1
+  package_info_plus: ^8.0.0
+  url_launcher: ^6.3.0
   hark_platform:
     path: packages/hark_platform
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <flutter_tts/flutter_tts_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <speech_to_text_windows/speech_to_text_windows.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterGemmaPluginRegisterWithRegistrar(
@@ -20,4 +21,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   SpeechToTextWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SpeechToTextWindows"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_tts
   permission_handler_windows
   speech_to_text_windows
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary

Adds a `/settings` route reachable from a new gear icon in the chat header. First Hark settings surface — four sections, no hidden dials.

- **Permissions** — live status for mic, notifications, and the default assistant role. Each row has a Grant/Open/Set button that falls through to app settings when permanently denied. Refreshes on app resume.
- **Wake word** — labeled **On/Off** toggle backed by a new `SettingsNotifier` that persists to `SharedPreferences` and calls `startWakeWordService` / `stopWakeWordService`. `ChatNotifier` now gates its init-time wake word start on the pref, so users who toggle off stay off across cold starts.
- **Models** — read-only rows for EmbeddingGemma 308M and Qwen3 0.6B plus the 201 KB `hey_harkh.onnx` wake word model and its 0.3 / 1500 ms config.
- **About** — version via `package_info_plus`, OACP protocol badge, GitHub link via `url_launcher`.

## Deferred to follow-ups

- Sensitivity slider (needs openWakeWord threshold plumbing through the service intent)
- Privacy indicator when mic is hot
- Model re-download / disk management
- Wake word battery measurement

## Test plan

- [ ] Gear icon in chat header opens Settings
- [ ] Permissions section shows correct state for mic, notifications, assistant role
- [ ] Grant button requests; falls through to app settings when permanently denied
- [ ] Wake word toggle Off → notification disappears, "Hey Hark" no longer triggers
- [ ] Cold start after toggling Off → wake word stays off
- [ ] Toggle On → notification returns, "Hey Hark" works again
- [ ] About shows correct version string + GitHub link opens in browser
- [ ] Back button returns to chat cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)