### PR TITLE
fix: sync wake word toggle when stopped from notification

### DIFF
--- a/android/app/src/main/kotlin/com/oacp/hark/HarkApplication.kt
+++ b/android/app/src/main/kotlin/com/oacp/hark/HarkApplication.kt
@@ -101,6 +101,19 @@ class HarkApplication : Application() {
     }
 
     /**
+     * Called by [WakeWordService] when the service is stopped via the
+     * notification "Stop" action (i.e. stopped externally, not from Dart).
+     * Notifies the main engine so [SettingsNotifier] can sync the toggle.
+     */
+    fun onWakeWordServiceStopped() {
+        Log.i(TAG, "Wake word service stopped externally — notifying Dart")
+        val mainEngine = FlutterEngineCache.getInstance()
+            .get(MAIN_ENGINE_ID) ?: return
+        val api = HarkResultFlutterApi(mainEngine.dartExecutor.binaryMessenger)
+        mainHandler.post { api.onWakeWordServiceStopped { } }
+    }
+
+    /**
      * Returns the cached overlay engine, or creates one on first call.
      *
      * The overlay engine runs the `overlayMain` Dart entrypoint and shares

--- a/android/app/src/main/kotlin/com/oacp/hark/WakeWordService.kt
+++ b/android/app/src/main/kotlin/com/oacp/hark/WakeWordService.kt
@@ -51,15 +51,19 @@ class WakeWordService : Service() {
                 Log.i(TAG, "Wake word service started")
             }
             ACTION_STOP -> {
+                val fromNotification = intent.getBooleanExtra(EXTRA_FROM_NOTIFICATION, false)
                 detector?.release()
                 detector = null
                 HarkPlatformPlugin.wakeWordRunning = false
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
-                Log.i(TAG, "Wake word service stopped")
-                // Notify Dart so SettingsNotifier can sync the toggle.
-                // Safe to call on all stop paths — the Dart handler is idempotent.
-                (application as HarkApplication).onWakeWordServiceStopped()
+                Log.i(TAG, "Wake word service stopped (fromNotification=$fromNotification)")
+                // Only notify Dart when the stop came from the notification.
+                // Dart-initiated stops already own their own state update —
+                // firing the callback there races with rapid re-enable.
+                if (fromNotification) {
+                    (application as HarkApplication).onWakeWordServiceStopped()
+                }
                 // Return NOT_STICKY so Android doesn't auto-restart us
                 // after the user explicitly stopped.
                 return START_NOT_STICKY
@@ -121,9 +125,12 @@ class WakeWordService : Service() {
             PendingIntent.FLAG_IMMUTABLE,
         )
         // "Stop" action: sends ACTION_STOP to ourselves, which releases
-        // the mic and removes the notification.
+        // the mic and removes the notification. The fromNotification flag
+        // tells the handler to fire the Dart sync callback (skipped on
+        // Dart-initiated stops to avoid a re-enable race).
         val stopIntent = Intent(this, WakeWordService::class.java).apply {
             action = ACTION_STOP
+            putExtra(EXTRA_FROM_NOTIFICATION, true)
         }
         val stopPendingIntent = PendingIntent.getService(
             this,
@@ -147,6 +154,7 @@ class WakeWordService : Service() {
         const val ACTION_STOP = "com.oacp.hark.WAKE_WORD_STOP"
         const val ACTION_PAUSE = "com.oacp.hark.WAKE_WORD_PAUSE"
         const val ACTION_RESUME = "com.oacp.hark.WAKE_WORD_RESUME"
+        const val EXTRA_FROM_NOTIFICATION = "com.oacp.hark.EXTRA_FROM_NOTIFICATION"
         const val NOTIFICATION_ID = 1001
     }
 }

--- a/android/app/src/main/kotlin/com/oacp/hark/WakeWordService.kt
+++ b/android/app/src/main/kotlin/com/oacp/hark/WakeWordService.kt
@@ -57,6 +57,9 @@ class WakeWordService : Service() {
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
                 Log.i(TAG, "Wake word service stopped")
+                // Notify Dart so SettingsNotifier can sync the toggle.
+                // Safe to call on all stop paths — the Dart handler is idempotent.
+                (application as HarkApplication).onWakeWordServiceStopped()
                 // Return NOT_STICKY so Android doesn't auto-restart us
                 // after the user explicitly stopped.
                 return START_NOT_STICKY

--- a/lib/services/oacp_result_service.dart
+++ b/lib/services/oacp_result_service.dart
@@ -56,9 +56,13 @@ class OacpResultService implements HarkResultFlutterApi {
 
   final _resultController = StreamController<OacpResult>.broadcast();
   final _wakeWordController = StreamController<void>.broadcast();
+  final _wakeWordStoppedController = StreamController<void>.broadcast();
 
   Stream<OacpResult> get results => _resultController.stream;
   Stream<void> get wakeWordDetections => _wakeWordController.stream;
+  /// Fires when the wake word service is stopped externally (e.g. notification
+  /// "Stop" button), so listeners can sync UI state.
+  Stream<void> get wakeWordServiceStopped => _wakeWordStoppedController.stream;
 
   @override
   void onOacpResult(OacpResultMessage result) {
@@ -70,9 +74,15 @@ class OacpResultService implements HarkResultFlutterApi {
     _wakeWordController.add(null);
   }
 
+  @override
+  void onWakeWordServiceStopped() {
+    _wakeWordStoppedController.add(null);
+  }
+
   void dispose() {
     HarkResultFlutterApi.setUp(null);
     _resultController.close();
     _wakeWordController.close();
+    _wakeWordStoppedController.close();
   }
 }

--- a/lib/state/settings_notifier.dart
+++ b/lib/state/settings_notifier.dart
@@ -30,7 +30,25 @@ class SettingsNotifier extends AsyncNotifier<SettingsState> {
     ref.onDispose(sub.cancel);
 
     final prefs = await SharedPreferences.getInstance();
-    final wakeWordEnabled = prefs.getBool(_kWakeWordEnabled) ?? true;
+    var wakeWordEnabled = prefs.getBool(_kWakeWordEnabled) ?? true;
+
+    // Reconcile pref with actual service state. Handles the case where the
+    // service was stopped (notification Stop, system kill, crash) while
+    // SettingsNotifier wasn't built — the broadcast stream event would have
+    // been dropped, leaving the pref stale.
+    if (wakeWordEnabled) {
+      try {
+        final running = await _commonApi.isWakeWordRunning();
+        if (!running) {
+          debugPrint('SettingsNotifier: pref says on but service dead — reconciling');
+          await prefs.setBool(_kWakeWordEnabled, false);
+          wakeWordEnabled = false;
+        }
+      } catch (e) {
+        debugPrint('SettingsNotifier: isWakeWordRunning check failed: $e');
+      }
+    }
+
     return SettingsState(wakeWordEnabled: wakeWordEnabled);
   }
 

--- a/lib/state/settings_notifier.dart
+++ b/lib/state/settings_notifier.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hark_platform/hark_platform.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'services_providers.dart';
+
 const _kWakeWordEnabled = 'wake_word_enabled';
 
 /// User-tunable settings backed by [SharedPreferences].
@@ -16,6 +18,17 @@ class SettingsNotifier extends AsyncNotifier<SettingsState> {
 
   @override
   Future<SettingsState> build() async {
+    // Subscribe to external service-stopped events (e.g. notification "Stop"
+    // button). Updates pref + state so the toggle stays in sync.
+    final resultService = ref.read(oacpResultServiceProvider);
+    final sub = resultService.wakeWordServiceStopped.listen((_) async {
+      debugPrint('SettingsNotifier: wake word service stopped externally');
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_kWakeWordEnabled, false);
+      state = const AsyncData(SettingsState(wakeWordEnabled: false));
+    });
+    ref.onDispose(sub.cancel);
+
     final prefs = await SharedPreferences.getInstance();
     final wakeWordEnabled = prefs.getBool(_kWakeWordEnabled) ?? true;
     return SettingsState(wakeWordEnabled: wakeWordEnabled);

--- a/packages/hark_platform/android/src/main/kotlin/com/oacp/hark_platform/Messages.g.kt
+++ b/packages/hark_platform/android/src/main/kotlin/com/oacp/hark_platform/Messages.g.kt
@@ -880,4 +880,25 @@ class HarkResultFlutterApi(private val binaryMessenger: BinaryMessenger, private
       } 
     }
   }
+  /**
+   * Called when the wake word service is stopped externally (e.g. via the
+   * notification "Stop" action), so Dart can sync the settings toggle.
+   */
+  fun onWakeWordServiceStopped(callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.hark_platform.HarkResultFlutterApi.onWakeWordServiceStopped$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(null) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(createConnectionError(channelName)))
+      } 
+    }
+  }
 }

--- a/packages/hark_platform/lib/src/messages.g.dart
+++ b/packages/hark_platform/lib/src/messages.g.dart
@@ -1016,6 +1016,10 @@ abstract class HarkResultFlutterApi {
 
   void onWakeWordDetected();
 
+  /// Called when the wake word service is stopped externally (e.g. via the
+  /// notification "Stop" action), so Dart can sync the settings toggle.
+  void onWakeWordServiceStopped();
+
   static void setUp(HarkResultFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
@@ -1053,6 +1057,25 @@ abstract class HarkResultFlutterApi {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           try {
             api.onWakeWordDetected();
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.hark_platform.HarkResultFlutterApi.onWakeWordServiceStopped$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          try {
+            api.onWakeWordServiceStopped();
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/hark_platform/pigeons/messages.dart
+++ b/packages/hark_platform/pigeons/messages.dart
@@ -179,4 +179,7 @@ abstract class HarkMainFlutterApi {
 abstract class HarkResultFlutterApi {
   void onOacpResult(OacpResultMessage result);
   void onWakeWordDetected();
+  /// Called when the wake word service is stopped externally (e.g. via the
+  /// notification "Stop" action), so Dart can sync the settings toggle.
+  void onWakeWordServiceStopped();
 }


### PR DESCRIPTION
## Summary

- Tapping **Stop** in the wake word notification now turns the Settings toggle off
- Previously: foreground service stopped, but `SharedPreferences` and `SettingsNotifier` were never updated — toggle showed ON even though detection was dead
- New Pigeon callback `onWakeWordServiceStopped` flows `WakeWordService → HarkApplication → Dart`
- `SettingsNotifier.build()` subscribes to a new `wakeWordServiceStopped` stream; on event it writes pref to `false` and updates state — idempotent when already off

## Changes

| File | Change |
|------|--------|
| `pigeons/messages.dart` + generated | Add `onWakeWordServiceStopped()` to `HarkResultFlutterApi` |
| `WakeWordService.kt` | Call `HarkApplication.onWakeWordServiceStopped()` in `ACTION_STOP` |
| `HarkApplication.kt` | New callback fires Pigeon event to main engine |
| `OacpResultService.dart` | Expose `wakeWordServiceStopped` broadcast stream |
| `SettingsNotifier.dart` | Subscribe in `build()`, sync pref + state |

## Test plan

- [ ] Enable wake word, background Hark, pull down notification shade, tap **Stop** → open Settings → toggle shows **off**
- [ ] Toggle off from Settings screen → service stops, toggle stays off (no double-fire regression)
- [ ] Toggle back on → wake word resumes → "Hey Hark" still detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)