### PR TITLE
feat(telemetry): per-stage NLU resolution timings (BYOK Slice 0)

### DIFF
--- a/lib/models/command_resolution.dart
+++ b/lib/models/command_resolution.dart
@@ -13,21 +13,37 @@ class CommandResolutionResult {
   final String? message;
   final String? modelId;
 
+  /// Optional per-stage timing and backend metadata populated by the
+  /// resolver. Threaded out to [LoggingCommandResolver] so we can compare
+  /// local vs cloud stage-2 latency without scraping logs. Keys today:
+  /// `stage1_ms`, `stage2_ms`, `stage2_backend`.
+  final Map<String, dynamic>? metrics;
+
   const CommandResolutionResult._({
     this.action,
     this.errorType,
     this.message,
     this.modelId,
+    this.metrics,
   });
 
-  const CommandResolutionResult.success(ResolvedAction action, {String? modelId})
-    : this._(action: action, modelId: modelId);
+  const CommandResolutionResult.success(
+    ResolvedAction action, {
+    String? modelId,
+    Map<String, dynamic>? metrics,
+  }) : this._(action: action, modelId: modelId, metrics: metrics);
 
   const CommandResolutionResult.failure(
     CommandResolutionErrorType errorType, {
     String? message,
     String? modelId,
-  }) : this._(errorType: errorType, message: message, modelId: modelId);
+    Map<String, dynamic>? metrics,
+  }) : this._(
+          errorType: errorType,
+          message: message,
+          modelId: modelId,
+          metrics: metrics,
+        );
 
   bool get isSuccess => action != null;
 }

--- a/lib/services/inference_logger.dart
+++ b/lib/services/inference_logger.dart
@@ -17,6 +17,19 @@ class InferenceLogEntry {
   final String? errorMessage;
   final int elapsedMs;
 
+  /// Stage-1 (embedding rank) latency in ms. Null on fast-path hits or
+  /// pre-rank failures (no actions registered).
+  final int? stage1Ms;
+
+  /// Stage-2 (slot fill) latency in ms. Null when stage 2 was not reached
+  /// (fast path, gating failure, no actions).
+  final int? stage2Ms;
+
+  /// Identifier for the stage-2 backend that produced the parameters.
+  /// Today: `qwen3_local` or `fast_path`. Future: `openai_compat`,
+  /// `anthropic`, `cache`, etc.
+  final String? stage2Backend;
+
   const InferenceLogEntry({
     required this.timestamp,
     required this.modelId,
@@ -29,6 +42,9 @@ class InferenceLogEntry {
     this.errorType,
     this.errorMessage,
     required this.elapsedMs,
+    this.stage1Ms,
+    this.stage2Ms,
+    this.stage2Backend,
   });
 
   Map<String, dynamic> toJson() => {
@@ -44,6 +60,9 @@ class InferenceLogEntry {
         if (errorType != null) 'error_type': errorType,
         if (errorMessage != null) 'error_message': errorMessage,
         'elapsed_ms': elapsedMs,
+        if (stage1Ms != null) 'stage1_ms': stage1Ms,
+        if (stage2Ms != null) 'stage2_ms': stage2Ms,
+        if (stage2Backend != null) 'stage2_backend': stage2Backend,
       };
 }
 

--- a/lib/services/logging_command_resolver.dart
+++ b/lib/services/logging_command_resolver.dart
@@ -32,6 +32,7 @@ class LoggingCommandResolver implements CommandResolver {
     final result = await _delegate.resolveCommand(transcript, actions);
     stopwatch.stop();
 
+    final metrics = result.metrics;
     await _logger.log(InferenceLogEntry(
       timestamp: DateTime.now(),
       modelId: result.modelId ?? fallbackModelId,
@@ -44,6 +45,9 @@ class LoggingCommandResolver implements CommandResolver {
       errorType: result.errorType?.name,
       errorMessage: result.message,
       elapsedMs: stopwatch.elapsedMilliseconds,
+      stage1Ms: metrics?['stage1_ms'] as int?,
+      stage2Ms: metrics?['stage2_ms'] as int?,
+      stage2Backend: metrics?['stage2_backend'] as String?,
     ));
 
     return result;

--- a/lib/services/logging_command_resolver.dart
+++ b/lib/services/logging_command_resolver.dart
@@ -37,11 +37,14 @@ class LoggingCommandResolver implements CommandResolver {
     final metrics = result.metrics;
     // Grep-able metrics line for device verification without pulling log
     // files: `adb logcat | grep HarkMetrics`.
+    final stage1 = metrics?['stage1_ms'];
+    final stage2 = metrics?['stage2_ms'];
+    final backend = metrics?['stage2_backend'];
     debugPrint(
       'HarkMetrics: total=${stopwatch.elapsedMilliseconds}ms '
-      'stage1=${metrics?['stage1_ms']}ms '
-      'stage2=${metrics?['stage2_ms']}ms '
-      'backend=${metrics?['stage2_backend']} '
+      'stage1=${stage1 != null ? "${stage1}ms" : "-"} '
+      'stage2=${stage2 != null ? "${stage2}ms" : "-"} '
+      'backend=${backend ?? "-"} '
       'success=${result.isSuccess}',
     );
     await _logger.log(InferenceLogEntry(

--- a/lib/services/logging_command_resolver.dart
+++ b/lib/services/logging_command_resolver.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../models/assistant_action.dart';
 import '../models/command_resolution.dart';
 import 'command_resolver.dart';
@@ -33,6 +35,15 @@ class LoggingCommandResolver implements CommandResolver {
     stopwatch.stop();
 
     final metrics = result.metrics;
+    // Grep-able metrics line for device verification without pulling log
+    // files: `adb logcat | grep HarkMetrics`.
+    debugPrint(
+      'HarkMetrics: total=${stopwatch.elapsedMilliseconds}ms '
+      'stage1=${metrics?['stage1_ms']}ms '
+      'stage2=${metrics?['stage2_ms']}ms '
+      'backend=${metrics?['stage2_backend']} '
+      'success=${result.isSuccess}',
+    );
     await _logger.log(InferenceLogEntry(
       timestamp: DateTime.now(),
       modelId: result.modelId ?? fallbackModelId,

--- a/lib/services/nlu_command_resolver.dart
+++ b/lib/services/nlu_command_resolver.dart
@@ -81,11 +81,18 @@ class NluCommandResolver implements CommandResolver {
     String transcript,
     List<AssistantAction> actions,
   ) async {
+    // Per-resolution metrics threaded out via [CommandResolutionResult] so
+    // [LoggingCommandResolver] can log per-stage timings without scraping
+    // logs. Keys: stage1_ms (embedding rank), stage2_ms (slot fill),
+    // stage2_backend ('qwen3_local' / 'fast_path' / future cloud backends).
+    final metrics = <String, dynamic>{};
+
     if (actions.isEmpty) {
       return CommandResolutionResult.failure(
         CommandResolutionErrorType.unavailable,
         message: 'No OACP actions are registered yet.',
         modelId: modelId,
+        metrics: metrics,
       );
     }
 
@@ -96,6 +103,7 @@ class NluCommandResolver implements CommandResolver {
     // models have finished loading.
     final fastPath = _tryKeywordFastPath(transcript, actions);
     if (fastPath != null) {
+      metrics['stage2_backend'] = 'fast_path';
       _debugLog('resolve_fast_path', {
         'transcript': transcript,
         'modelId': modelId,
@@ -113,10 +121,18 @@ class NluCommandResolver implements CommandResolver {
         },
         confirmationMessage: fastPath.confirmationMessage,
       );
-      return CommandResolutionResult.success(resolved, modelId: modelId);
+      return CommandResolutionResult.success(
+        resolved,
+        modelId: modelId,
+        metrics: metrics,
+      );
     }
 
+    final swStage1 = Stopwatch()..start();
     final rankedOptions = await _rankActions(transcript, actions);
+    swStage1.stop();
+    metrics['stage1_ms'] = swStage1.elapsedMilliseconds;
+
     _debugLog('resolve_ranked', {
       'transcript': transcript,
       'modelId': modelId,
@@ -140,6 +156,7 @@ class NluCommandResolver implements CommandResolver {
         CommandResolutionErrorType.noMatch,
         message: 'No matching action was found.',
         modelId: modelId,
+        metrics: metrics,
       );
     }
 
@@ -156,6 +173,7 @@ class NluCommandResolver implements CommandResolver {
         CommandResolutionErrorType.noMatch,
         message: 'No matching action was found.',
         modelId: modelId,
+        metrics: metrics,
       );
     }
 
@@ -174,18 +192,25 @@ class NluCommandResolver implements CommandResolver {
         CommandResolutionErrorType.noMatch,
         message: 'The command was too ambiguous to match confidently.',
         modelId: modelId,
+        metrics: metrics,
       );
     }
 
     // Layer 2: Slot filling via on-device LLM.
+    // TODO(byok): when cloud routing lands, the backend label here will be
+    // determined by which slotFill closure was injected, not hardcoded.
     final action = best.action;
     final Map<String, dynamic>? parameters;
+    final swStage2 = Stopwatch()..start();
     try {
       parameters = await slotFill(
         transcript: transcript,
         action: action,
       );
     } on StateError {
+      swStage2.stop();
+      metrics['stage2_ms'] = swStage2.elapsedMilliseconds;
+      metrics['stage2_backend'] = 'qwen3_local';
       _debugLog('resolve_declined', {
         'transcript': transcript,
         'modelId': modelId,
@@ -196,8 +221,12 @@ class NluCommandResolver implements CommandResolver {
         CommandResolutionErrorType.unavailable,
         message: 'The slot-filling model is not available.',
         modelId: modelId,
+        metrics: metrics,
       );
     }
+    swStage2.stop();
+    metrics['stage2_ms'] = swStage2.elapsedMilliseconds;
+    metrics['stage2_backend'] = 'qwen3_local';
 
     if (parameters == null) {
       _debugLog('resolve_declined', {
@@ -210,6 +239,7 @@ class NluCommandResolver implements CommandResolver {
         CommandResolutionErrorType.invalidResponse,
         message: 'The selected action is missing required parameters.',
         modelId: modelId,
+        metrics: metrics,
       );
     }
 
@@ -229,7 +259,11 @@ class NluCommandResolver implements CommandResolver {
       'score': best.score,
       'parameters': resolved.parameters,
     });
-    return CommandResolutionResult.success(resolved, modelId: modelId);
+    return CommandResolutionResult.success(
+      resolved,
+      modelId: modelId,
+      metrics: metrics,
+    );
   }
 
   bool _isConfidentMatch(List<_RankedAction> rankedOptions) {


### PR DESCRIPTION
## Summary

Baseline telemetry for the upcoming BYOK cloud-brain work. Adds optional `stage1_ms` / `stage2_ms` / `stage2_backend` fields to the inference log so we can measure embedding-rank latency separately from slot-fill latency.

**No behavior change.** Pure instrumentation.

## Why now

Stage 2 (slot fill via Qwen3 0.6B) is the single biggest UX pain in Hark today (1–3 s per command). The plan is to optionally replace it with a cloud LLM. Without per-stage timings we have no honest way to claim "X% faster" once a cloud slot-filler is wired in — `LoggingCommandResolver` only sees the total `resolveCommand()` time today.

## Architecture

- `CommandResolutionResult` gains an optional `metrics: Map<String, dynamic>?` field, plumbed through both `.success` and `.failure` constructors
- `NluCommandResolver.resolveCommand` wraps `_rankActions()` and the `slotFill()` invocation in `Stopwatch`es and populates the metrics map on every return path
- `InferenceLogEntry` gains optional `stage1Ms` / `stage2Ms` / `stage2Backend` fields + JSON serialization
- `LoggingCommandResolver` reads `result.metrics` and passes the values through to the log entry

## stage2_backend values

| Value | When |
|---|---|
| `qwen3_local` | Current on-device slot fill via flutter_gemma |
| `fast_path`   | Keyword/alias short-circuit before any model runs |

Future (cloud routing): `openai_compat`, `anthropic`, `cache`.

## Test plan

- [ ] Run 5–10 commands on device. Confirm `inference_<date>.jsonl` shows `stage1_ms`, `stage2_ms`, `stage2_backend` for the slow path
- [ ] Trigger a fast-path command (e.g. "scan qr code"). Confirm `stage2_backend: "fast_path"` with no `stage1_ms` / `stage2_ms`
- [ ] Trigger a no-match command (gibberish). Confirm `stage1_ms` populated, no `stage2_ms`
- [ ] Confirm existing fields (`elapsed_ms`, `success`, etc.) still present in the log entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)