### PR TITLE
feat(cloud): secure storage + provider config model (BYOK Slice 1)

### DIFF
--- a/lib/services/cloud/cloud_provider_config.dart
+++ b/lib/services/cloud/cloud_provider_config.dart
@@ -8,6 +8,23 @@
 /// and the settings UI can dispatch on auth style — not so we can bake
 /// vendor defaults into the data model.
 ///
+/// TODO(byok-simplify): 5 subclasses but 4 are structurally identical
+/// (baseUrl + apiKey + model). Only [AzureConfig] adds `apiVersion`.
+/// After Slice 4 lands and we know the real adapter shape, consider
+/// collapsing to `CloudProviderConfig(kind, baseUrl, apiKey, model,
+/// extras: Map<String,String>)`. The "type safety" of the sealed union
+/// is illusory — the adapter already runtime-switches on `kind` for
+/// auth header selection, and downcasting to reach `apiVersion` is the
+/// same runtime check as `extras['api_version']`. Only keep the sealed
+/// shape if a provider with structurally different fields shows up
+/// (e.g. AWS Bedrock with region + access_key_id + secret + session).
+///
+/// TODO(byok-schema-version): Persistence blobs have no `_version`
+/// field today. Adding one now (`_version: 1`) would be free insurance
+/// for future wire-format changes — impossible to retrofit cleanly
+/// once existing installs have blobs without it. Bundle with the
+/// sealed-union refactor above or do standalone.
+///
 /// Stored in `flutter_secure_storage` via [CloudProviderNotifier]. The
 /// API key is the only field that MUST live in secure storage; the rest
 /// could live in shared prefs, but keeping everything together
@@ -116,6 +133,10 @@ sealed class CloudProviderConfig {
 
   CloudProviderKind get kind;
 
+  // TODO(byok-log-audit): `toJson` returns the raw apiKey for
+  // persistence. Any future code doing `debugPrint('${cfg.toJson()}')`
+  // would leak the key. Audit / lint when Slice 6 lands its verbose-
+  // logging toggle.
   Map<String, dynamic> toJson();
 
   /// Parse a previously-persisted config blob. Throws [ArgumentError]

--- a/lib/services/cloud/cloud_provider_config.dart
+++ b/lib/services/cloud/cloud_provider_config.dart
@@ -1,0 +1,305 @@
+/// Models the user-configured cloud LLM backend used for stage-2
+/// parameter extraction. One of several provider-specific config shapes
+/// plus a routing mode that decides when to actually call the cloud.
+///
+/// Stored in `flutter_secure_storage` via [CloudProviderNotifier]. The
+/// API key is the only field that MUST live in secure storage; the rest
+/// (provider kind, base URL, model, region) could live in shared prefs,
+/// but keeping everything together simplifies read/write atomicity.
+///
+/// Non-goals for this file:
+/// - Any network code
+/// - Any UI
+/// - Any validation against live provider endpoints
+///
+/// See `temp/byok-implementation-plan-2026-04-13.md` for the broader
+/// rationale (Slice 1).
+library;
+
+import 'dart:convert';
+
+/// Which cloud provider the user has configured.
+enum CloudProviderKind {
+  openai('openai'),
+  azureOpenAi('azure'),
+  gemini('gemini'),
+  anthropic('anthropic'),
+  customOpenAi('custom_openai');
+
+  const CloudProviderKind(this.wireName);
+
+  /// Stable string used in JSON persistence. Do not change without a
+  /// migration — existing secure-storage blobs rely on this value.
+  final String wireName;
+
+  static CloudProviderKind fromWireName(String name) {
+    for (final kind in CloudProviderKind.values) {
+      if (kind.wireName == name) return kind;
+    }
+    throw ArgumentError('Unknown CloudProviderKind wireName: $name');
+  }
+}
+
+/// Routing mode for stage-2 parameter extraction. Determines how
+/// [CloudSlotFiller] and the local Qwen3 fallback interact.
+enum CloudRoutingMode {
+  /// Always run the on-device slot filler. Ignore any configured cloud
+  /// provider. The default when no API key is present.
+  localOnly('local_only'),
+
+  /// Try cloud first when a key is configured and the network is up.
+  /// Fall back to on-device slot fill on any [CloudUnavailableError]
+  /// (network, 401, 429, malformed response). Recommended default
+  /// after a key is saved.
+  cloudPreferred('cloud_preferred'),
+
+  /// Always run cloud. Refuse to fall back silently. Surface a hard
+  /// error to the user on any failure. Opt-in for users who would
+  /// rather see a clear failure than an inconsistent backend.
+  cloudOnly('cloud_only');
+
+  const CloudRoutingMode(this.wireName);
+  final String wireName;
+
+  static CloudRoutingMode fromWireName(String name) {
+    for (final mode in CloudRoutingMode.values) {
+      if (mode.wireName == name) return mode;
+    }
+    throw ArgumentError('Unknown CloudRoutingMode wireName: $name');
+  }
+}
+
+/// Sealed base for all cloud provider configurations. Each concrete
+/// subclass carries the fields that that provider needs to build a
+/// request: base URL, model identifier, auth material.
+///
+/// The API key is stored alongside the rest of the config because
+/// [CloudProviderNotifier] writes/reads everything through a single
+/// secure-storage blob — simpler than splitting keys from config.
+sealed class CloudProviderConfig {
+  const CloudProviderConfig({
+    required this.apiKey,
+    required this.model,
+  });
+
+  /// The user's API key. Never log this field. Never include it in
+  /// crash reports. See `temp/byok-research-2026-04-13.md` §6.
+  final String apiKey;
+
+  /// Model identifier as the provider expects it. For Azure this is
+  /// the *deployment name*, NOT the base model name.
+  final String model;
+
+  CloudProviderKind get kind;
+
+  /// The base URL used by [OpenAiCompatibleAdapter] or the provider's
+  /// native adapter. For Azure, this is the resource/v1 shape; for
+  /// custom OpenAI-compatible providers, the user-supplied URL.
+  String get baseUrl;
+
+  Map<String, dynamic> toJson();
+
+  /// Parse a previously-persisted config blob. Throws [ArgumentError]
+  /// on unknown kinds or malformed input — callers should treat that
+  /// as "no config stored" and prompt the user to re-enter.
+  static CloudProviderConfig fromJson(Map<String, dynamic> json) {
+    final kindRaw = json['kind'] as String?;
+    if (kindRaw == null) {
+      throw ArgumentError('CloudProviderConfig JSON missing "kind" field');
+    }
+    final kind = CloudProviderKind.fromWireName(kindRaw);
+    switch (kind) {
+      case CloudProviderKind.openai:
+        return OpenAiConfig.fromJson(json);
+      case CloudProviderKind.azureOpenAi:
+        return AzureConfig.fromJson(json);
+      case CloudProviderKind.gemini:
+        return GeminiConfig.fromJson(json);
+      case CloudProviderKind.anthropic:
+        return AnthropicConfig.fromJson(json);
+      case CloudProviderKind.customOpenAi:
+        return CustomOpenAiConfig.fromJson(json);
+    }
+  }
+
+  static CloudProviderConfig? fromJsonString(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      return fromJson(decoded);
+    } on FormatException {
+      return null;
+    } on TypeError {
+      return null;
+    } on ArgumentError {
+      return null;
+    }
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+}
+
+/// Vanilla OpenAI direct (`api.openai.com`).
+class OpenAiConfig extends CloudProviderConfig {
+  const OpenAiConfig({
+    required super.apiKey,
+    super.model = 'gpt-4o-mini',
+  });
+
+  @override
+  CloudProviderKind get kind => CloudProviderKind.openai;
+
+  @override
+  String get baseUrl => 'https://api.openai.com/v1';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.wireName,
+        'api_key': apiKey,
+        'model': model,
+      };
+
+  factory OpenAiConfig.fromJson(Map<String, dynamic> json) => OpenAiConfig(
+        apiKey: json['api_key'] as String,
+        model: (json['model'] as String?) ?? 'gpt-4o-mini',
+      );
+}
+
+/// Azure OpenAI. Uses the v1/Foundry surface (`/openai/v1/...`) which
+/// accepts `model` in the request body like vanilla OpenAI, instead of
+/// the classic per-deployment URL. See
+/// `temp/byok-research-2026-04-13.md` §1 for why.
+class AzureConfig extends CloudProviderConfig {
+  const AzureConfig({
+    required super.apiKey,
+    required this.resourceName,
+    required super.model,
+    this.apiVersion = '2024-10-21',
+  });
+
+  /// The Azure resource subdomain, e.g. `my-hark-resource` for
+  /// `https://my-hark-resource.openai.azure.com`.
+  final String resourceName;
+
+  /// API version query parameter. Pinned to a known-good value by
+  /// default; users on newer regions may need to bump it.
+  final String apiVersion;
+
+  @override
+  CloudProviderKind get kind => CloudProviderKind.azureOpenAi;
+
+  @override
+  String get baseUrl => 'https://$resourceName.openai.azure.com/openai/v1';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.wireName,
+        'api_key': apiKey,
+        'model': model,
+        'resource_name': resourceName,
+        'api_version': apiVersion,
+      };
+
+  factory AzureConfig.fromJson(Map<String, dynamic> json) => AzureConfig(
+        apiKey: json['api_key'] as String,
+        resourceName: json['resource_name'] as String,
+        model: json['model'] as String,
+        apiVersion:
+            (json['api_version'] as String?) ?? '2024-10-21',
+      );
+}
+
+/// Google Gemini via the OpenAI-compatibility endpoint. We intentionally
+/// target the compat shape from day one so [OpenAiCompatibleAdapter]
+/// covers it without a separate Gemini adapter.
+class GeminiConfig extends CloudProviderConfig {
+  const GeminiConfig({
+    required super.apiKey,
+    super.model = 'gemini-2.5-flash-lite',
+  });
+
+  @override
+  CloudProviderKind get kind => CloudProviderKind.gemini;
+
+  @override
+  String get baseUrl =>
+      'https://generativelanguage.googleapis.com/v1beta/openai';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.wireName,
+        'api_key': apiKey,
+        'model': model,
+      };
+
+  factory GeminiConfig.fromJson(Map<String, dynamic> json) => GeminiConfig(
+        apiKey: json['api_key'] as String,
+        model: (json['model'] as String?) ?? 'gemini-2.5-flash-lite',
+      );
+}
+
+/// Anthropic Claude. Native shape — handled by a dedicated adapter in
+/// Slice 7, not by [OpenAiCompatibleAdapter]. This config is declared
+/// now so the storage layer, UI, and routing code only need to learn
+/// about it once.
+class AnthropicConfig extends CloudProviderConfig {
+  const AnthropicConfig({
+    required super.apiKey,
+    super.model = 'claude-haiku-4-5',
+  });
+
+  @override
+  CloudProviderKind get kind => CloudProviderKind.anthropic;
+
+  @override
+  String get baseUrl => 'https://api.anthropic.com/v1';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.wireName,
+        'api_key': apiKey,
+        'model': model,
+      };
+
+  factory AnthropicConfig.fromJson(Map<String, dynamic> json) =>
+      AnthropicConfig(
+        apiKey: json['api_key'] as String,
+        model: (json['model'] as String?) ?? 'claude-haiku-4-5',
+      );
+}
+
+/// Custom OpenAI-compatible endpoint. Covers OpenRouter, LiteLLM, vLLM,
+/// Together, Groq, self-hosted, and anything else that implements the
+/// OpenAI `/v1/chat/completions` (or `/v1/responses`) shape.
+class CustomOpenAiConfig extends CloudProviderConfig {
+  const CustomOpenAiConfig({
+    required super.apiKey,
+    required super.model,
+    required this.customBaseUrl,
+  });
+
+  /// User-provided base URL. Should not include `/chat/completions` —
+  /// the adapter appends the relevant path.
+  final String customBaseUrl;
+
+  @override
+  CloudProviderKind get kind => CloudProviderKind.customOpenAi;
+
+  @override
+  String get baseUrl => customBaseUrl;
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'kind': kind.wireName,
+        'api_key': apiKey,
+        'model': model,
+        'custom_base_url': customBaseUrl,
+      };
+
+  factory CustomOpenAiConfig.fromJson(Map<String, dynamic> json) =>
+      CustomOpenAiConfig(
+        apiKey: json['api_key'] as String,
+        model: json['model'] as String,
+        customBaseUrl: json['custom_base_url'] as String,
+      );
+}

--- a/lib/services/cloud/cloud_provider_config.dart
+++ b/lib/services/cloud/cloud_provider_config.dart
@@ -2,15 +2,22 @@
 /// parameter extraction. One of several provider-specific config shapes
 /// plus a routing mode that decides when to actually call the cloud.
 ///
+/// **No hardcoded URLs, no default model names.** The user supplies
+/// every field (base URL, API key, model / deployment name, and any
+/// provider-specific extras). The sealed union exists only so adapters
+/// and the settings UI can dispatch on auth style — not so we can bake
+/// vendor defaults into the data model.
+///
 /// Stored in `flutter_secure_storage` via [CloudProviderNotifier]. The
 /// API key is the only field that MUST live in secure storage; the rest
-/// (provider kind, base URL, model, region) could live in shared prefs,
-/// but keeping everything together simplifies read/write atomicity.
+/// could live in shared prefs, but keeping everything together
+/// simplifies read/write atomicity.
 ///
 /// Non-goals for this file:
 /// - Any network code
 /// - Any UI
 /// - Any validation against live provider endpoints
+/// - Any vendor-specific defaults (URLs, model names)
 ///
 /// See `temp/byok-implementation-plan-2026-04-13.md` for the broader
 /// rationale (Slice 1).
@@ -18,7 +25,8 @@ library;
 
 import 'dart:convert';
 
-/// Which cloud provider the user has configured.
+/// Which cloud provider the user has configured. Drives which auth
+/// header the adapter emits and which fields the settings screen shows.
 enum CloudProviderKind {
   openai('openai'),
   azureOpenAi('azure'),
@@ -73,29 +81,40 @@ enum CloudRoutingMode {
 /// subclass carries the fields that that provider needs to build a
 /// request: base URL, model identifier, auth material.
 ///
+/// **Every field is user-supplied.** There are no defaults. The
+/// settings screen is responsible for any placeholder text or
+/// convenience suggestions it wants to offer.
+///
 /// The API key is stored alongside the rest of the config because
 /// [CloudProviderNotifier] writes/reads everything through a single
 /// secure-storage blob — simpler than splitting keys from config.
 sealed class CloudProviderConfig {
   const CloudProviderConfig({
+    required this.baseUrl,
     required this.apiKey,
     required this.model,
   });
+
+  /// Base URL for the provider's API. User-supplied, no trailing
+  /// `/chat/completions` — the adapter appends the route it needs.
+  ///
+  /// Examples users might type:
+  /// - `https://api.openai.com/v1`
+  /// - `https://my-resource.openai.azure.com/openai/v1`
+  /// - `https://openrouter.ai/api/v1`
+  /// - `https://api.anthropic.com/v1`
+  final String baseUrl;
 
   /// The user's API key. Never log this field. Never include it in
   /// crash reports. See `temp/byok-research-2026-04-13.md` §6.
   final String apiKey;
 
-  /// Model identifier as the provider expects it. For Azure this is
-  /// the *deployment name*, NOT the base model name.
+  /// Model / deployment identifier as the provider expects it in the
+  /// request body. For Azure this is the deployment name. For OpenAI,
+  /// Gemini, Anthropic, and custom endpoints this is the model id.
   final String model;
 
   CloudProviderKind get kind;
-
-  /// The base URL used by [OpenAiCompatibleAdapter] or the provider's
-  /// native adapter. For Azure, this is the resource/v1 shape; for
-  /// custom OpenAI-compatible providers, the user-supplied URL.
-  String get baseUrl;
 
   Map<String, dynamic> toJson();
 
@@ -137,104 +156,103 @@ sealed class CloudProviderConfig {
   }
 
   String toJsonString() => jsonEncode(toJson());
+
+  /// toString intentionally omits the API key so accidental debug logs
+  /// never leak secrets. Subclasses should override if they add
+  /// additional sensitive fields.
+  @override
+  String toString() =>
+      '${runtimeType}(baseUrl: $baseUrl, model: $model, apiKey: <redacted>)';
 }
 
-/// Vanilla OpenAI direct (`api.openai.com`).
+/// Vanilla OpenAI direct. Auth via `Authorization: Bearer`.
 class OpenAiConfig extends CloudProviderConfig {
   const OpenAiConfig({
+    required super.baseUrl,
     required super.apiKey,
-    super.model = 'gpt-4o-mini',
+    required super.model,
   });
 
   @override
   CloudProviderKind get kind => CloudProviderKind.openai;
 
   @override
-  String get baseUrl => 'https://api.openai.com/v1';
-
-  @override
   Map<String, dynamic> toJson() => {
         'kind': kind.wireName,
+        'base_url': baseUrl,
         'api_key': apiKey,
         'model': model,
       };
 
   factory OpenAiConfig.fromJson(Map<String, dynamic> json) => OpenAiConfig(
+        baseUrl: json['base_url'] as String,
         apiKey: json['api_key'] as String,
-        model: (json['model'] as String?) ?? 'gpt-4o-mini',
+        model: json['model'] as String,
       );
 }
 
-/// Azure OpenAI. Uses the v1/Foundry surface (`/openai/v1/...`) which
-/// accepts `model` in the request body like vanilla OpenAI, instead of
-/// the classic per-deployment URL. See
-/// `temp/byok-research-2026-04-13.md` §1 for why.
+/// Azure OpenAI. Auth via the `api-key` header (not `Authorization`).
+/// The user supplies the full base URL (typically the v1/Foundry
+/// surface `https://{resource}.openai.azure.com/openai/v1`), the
+/// deployment name (as [model]), and the API version query parameter.
 class AzureConfig extends CloudProviderConfig {
   const AzureConfig({
+    required super.baseUrl,
     required super.apiKey,
-    required this.resourceName,
     required super.model,
-    this.apiVersion = '2024-10-21',
+    required this.apiVersion,
   });
 
-  /// The Azure resource subdomain, e.g. `my-hark-resource` for
-  /// `https://my-hark-resource.openai.azure.com`.
-  final String resourceName;
-
-  /// API version query parameter. Pinned to a known-good value by
-  /// default; users on newer regions may need to bump it.
+  /// API version query parameter. User-supplied, no default — the
+  /// right value depends on the user's region and deployment date.
+  /// Example: `2024-10-21`.
   final String apiVersion;
 
   @override
   CloudProviderKind get kind => CloudProviderKind.azureOpenAi;
 
   @override
-  String get baseUrl => 'https://$resourceName.openai.azure.com/openai/v1';
-
-  @override
   Map<String, dynamic> toJson() => {
         'kind': kind.wireName,
+        'base_url': baseUrl,
         'api_key': apiKey,
         'model': model,
-        'resource_name': resourceName,
         'api_version': apiVersion,
       };
 
   factory AzureConfig.fromJson(Map<String, dynamic> json) => AzureConfig(
+        baseUrl: json['base_url'] as String,
         apiKey: json['api_key'] as String,
-        resourceName: json['resource_name'] as String,
         model: json['model'] as String,
-        apiVersion:
-            (json['api_version'] as String?) ?? '2024-10-21',
+        apiVersion: json['api_version'] as String,
       );
 }
 
-/// Google Gemini via the OpenAI-compatibility endpoint. We intentionally
-/// target the compat shape from day one so [OpenAiCompatibleAdapter]
-/// covers it without a separate Gemini adapter.
+/// Google Gemini. Auth via `x-goog-api-key` header, or via the
+/// OpenAI-compatibility endpoint with `Authorization: Bearer`. The
+/// adapter decides which based on the [baseUrl] the user supplied.
 class GeminiConfig extends CloudProviderConfig {
   const GeminiConfig({
+    required super.baseUrl,
     required super.apiKey,
-    super.model = 'gemini-2.5-flash-lite',
+    required super.model,
   });
 
   @override
   CloudProviderKind get kind => CloudProviderKind.gemini;
 
   @override
-  String get baseUrl =>
-      'https://generativelanguage.googleapis.com/v1beta/openai';
-
-  @override
   Map<String, dynamic> toJson() => {
         'kind': kind.wireName,
+        'base_url': baseUrl,
         'api_key': apiKey,
         'model': model,
       };
 
   factory GeminiConfig.fromJson(Map<String, dynamic> json) => GeminiConfig(
+        baseUrl: json['base_url'] as String,
         apiKey: json['api_key'] as String,
-        model: (json['model'] as String?) ?? 'gemini-2.5-flash-lite',
+        model: json['model'] as String,
       );
 }
 
@@ -242,64 +260,61 @@ class GeminiConfig extends CloudProviderConfig {
 /// Slice 7, not by [OpenAiCompatibleAdapter]. This config is declared
 /// now so the storage layer, UI, and routing code only need to learn
 /// about it once.
+///
+/// Auth via `x-api-key` + `anthropic-version` headers.
 class AnthropicConfig extends CloudProviderConfig {
   const AnthropicConfig({
+    required super.baseUrl,
     required super.apiKey,
-    super.model = 'claude-haiku-4-5',
+    required super.model,
   });
 
   @override
   CloudProviderKind get kind => CloudProviderKind.anthropic;
 
   @override
-  String get baseUrl => 'https://api.anthropic.com/v1';
-
-  @override
   Map<String, dynamic> toJson() => {
         'kind': kind.wireName,
+        'base_url': baseUrl,
         'api_key': apiKey,
         'model': model,
       };
 
   factory AnthropicConfig.fromJson(Map<String, dynamic> json) =>
       AnthropicConfig(
+        baseUrl: json['base_url'] as String,
         apiKey: json['api_key'] as String,
-        model: (json['model'] as String?) ?? 'claude-haiku-4-5',
+        model: json['model'] as String,
       );
 }
 
 /// Custom OpenAI-compatible endpoint. Covers OpenRouter, LiteLLM, vLLM,
 /// Together, Groq, self-hosted, and anything else that implements the
-/// OpenAI `/v1/chat/completions` (or `/v1/responses`) shape.
+/// OpenAI `/v1/chat/completions` (or `/v1/responses`) shape. Structurally
+/// identical to [OpenAiConfig]; kept as a distinct kind so the settings
+/// UI can offer different placeholder text and help copy.
 class CustomOpenAiConfig extends CloudProviderConfig {
   const CustomOpenAiConfig({
+    required super.baseUrl,
     required super.apiKey,
     required super.model,
-    required this.customBaseUrl,
   });
-
-  /// User-provided base URL. Should not include `/chat/completions` —
-  /// the adapter appends the relevant path.
-  final String customBaseUrl;
 
   @override
   CloudProviderKind get kind => CloudProviderKind.customOpenAi;
 
   @override
-  String get baseUrl => customBaseUrl;
-
-  @override
   Map<String, dynamic> toJson() => {
         'kind': kind.wireName,
+        'base_url': baseUrl,
         'api_key': apiKey,
         'model': model,
-        'custom_base_url': customBaseUrl,
       };
 
   factory CustomOpenAiConfig.fromJson(Map<String, dynamic> json) =>
       CustomOpenAiConfig(
+        baseUrl: json['base_url'] as String,
         apiKey: json['api_key'] as String,
         model: json['model'] as String,
-        customBaseUrl: json['custom_base_url'] as String,
       );
 }

--- a/lib/state/cloud_provider_notifier.dart
+++ b/lib/state/cloud_provider_notifier.dart
@@ -55,6 +55,12 @@ class CloudProviderState {
 /// mode. Reads from secure storage on build, persists changes eagerly,
 /// and emits `null` config when no key is present.
 ///
+/// TODO(byok-notifier-test): The load/save flow here is not unit-tested
+/// because `FlutterSecureStorage` is hard to mock. Slice 4 will
+/// exercise it live. If the adapter work exposes subtle bugs in the
+/// read/write race handling, add a dedicated test with a mocked
+/// secure-storage impl.
+///
 /// Intentionally not an [AsyncNotifier] — we want the resolver to be
 /// able to read the current state synchronously via `ref.read` during
 /// slot filling (Slice 4 wires this up), which an AsyncNotifier would
@@ -75,6 +81,10 @@ class CloudProviderNotifier extends Notifier<CloudProviderState> {
     // Consumers who need the loaded state can `await` [awaitInitialLoad]
     // once after construction; the resolver (Slice 4) will call it
     // during app init so the steady-state path is synchronous.
+    //
+    // TODO(byok-cleanup): `??=` is defensive dead code — `Notifier.build`
+    // runs exactly once per instance lifetime. Drop when confidence is
+    // high that no code path re-enters `build()`.
     _initialLoad ??= _loadFromStorage();
     return const CloudProviderState(
       config: null,

--- a/lib/state/cloud_provider_notifier.dart
+++ b/lib/state/cloud_provider_notifier.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/cloud/cloud_provider_config.dart';
+
+/// SharedPreferences key for the non-sensitive routing mode. Kept out
+/// of secure storage because (a) it's not secret and (b) putting enums
+/// in secure storage would make the "clear config" path harder.
+const _kCloudRoutingMode = 'cloud_routing_mode';
+
+/// Secure-storage key for the serialized [CloudProviderConfig] blob.
+/// Single JSON string so reads and writes are atomic.
+const _kCloudProviderConfigJson = 'cloud_provider_config_json';
+
+/// Android-side options for [FlutterSecureStorage]. Uses
+/// EncryptedSharedPreferences under the hood, backed by an AES key in
+/// the Android Keystore. See
+/// [flutter_secure_storage docs](https://pub.dev/packages/flutter_secure_storage).
+const _androidOptions = AndroidOptions(
+  encryptedSharedPreferences: true,
+);
+
+/// Immutable view of the user's cloud backend configuration plus the
+/// routing mode. Consumed by the resolver (Slice 4) and by the Cloud
+/// Brain settings screen (Slice 5).
+@immutable
+class CloudProviderState {
+  const CloudProviderState({
+    required this.config,
+    required this.mode,
+  });
+
+  /// Null when no key is configured yet. Routing should fall back to
+  /// local regardless of [mode] in that case.
+  final CloudProviderConfig? config;
+
+  final CloudRoutingMode mode;
+
+  bool get hasConfig => config != null;
+
+  CloudProviderState copyWith({
+    CloudProviderConfig? config,
+    bool clearConfig = false,
+    CloudRoutingMode? mode,
+  }) =>
+      CloudProviderState(
+        config: clearConfig ? null : (config ?? this.config),
+        mode: mode ?? this.mode,
+      );
+}
+
+/// Riverpod notifier that owns the user's BYOK cloud config and routing
+/// mode. Reads from secure storage on build, persists changes eagerly,
+/// and emits `null` config when no key is present.
+///
+/// Intentionally not an [AsyncNotifier] — we want the resolver to be
+/// able to read the current state synchronously via `ref.read` during
+/// slot filling (Slice 4 wires this up), which an AsyncNotifier would
+/// force into an `await`. The build-time load is tiny (one prefs read
+/// + one secure-storage read) so the short "empty" window is
+/// acceptable. See [awaitInitialLoad] for callers that need to block
+/// on the first load.
+class CloudProviderNotifier extends Notifier<CloudProviderState> {
+  final _secureStorage = const FlutterSecureStorage(
+    aOptions: _androidOptions,
+  );
+
+  Future<void>? _initialLoad;
+
+  @override
+  CloudProviderState build() {
+    // Kick off the async load but return a sensible default immediately.
+    // Consumers who need the loaded state can `await` [awaitInitialLoad]
+    // once after construction; the resolver (Slice 4) will call it
+    // during app init so the steady-state path is synchronous.
+    _initialLoad ??= _loadFromStorage();
+    return const CloudProviderState(
+      config: null,
+      mode: CloudRoutingMode.localOnly,
+    );
+  }
+
+  /// Returns a future that completes when the initial secure-storage
+  /// read has finished. Safe to call multiple times — the underlying
+  /// load runs exactly once per notifier instance.
+  Future<void> awaitInitialLoad() => _initialLoad ?? Future.value();
+
+  Future<void> _loadFromStorage() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final modeRaw = prefs.getString(_kCloudRoutingMode);
+      final mode = modeRaw == null
+          ? CloudRoutingMode.localOnly
+          : _safeParseMode(modeRaw);
+
+      final configRaw = await _secureStorage.read(key: _kCloudProviderConfigJson);
+      final config = CloudProviderConfig.fromJsonString(configRaw);
+
+      state = CloudProviderState(config: config, mode: mode);
+    } catch (e, st) {
+      debugPrint('CloudProviderNotifier: load failed: $e\n$st');
+      // Leave the default empty state in place — user can re-enter
+      // config via the settings screen.
+    }
+  }
+
+  CloudRoutingMode _safeParseMode(String raw) {
+    try {
+      return CloudRoutingMode.fromWireName(raw);
+    } on ArgumentError {
+      return CloudRoutingMode.localOnly;
+    }
+  }
+
+  /// Save or replace the cloud provider config. Does NOT change the
+  /// routing mode — callers that flip mode at the same time should
+  /// call [setMode] separately.
+  Future<void> setConfig(CloudProviderConfig config) async {
+    await awaitInitialLoad();
+    try {
+      await _secureStorage.write(
+        key: _kCloudProviderConfigJson,
+        value: config.toJsonString(),
+      );
+      state = state.copyWith(config: config);
+    } catch (e) {
+      debugPrint('CloudProviderNotifier: setConfig failed: $e');
+      rethrow;
+    }
+  }
+
+  /// Wipe the stored API key + config entirely. Routing falls back to
+  /// local regardless of the mode setting.
+  Future<void> clearConfig() async {
+    await awaitInitialLoad();
+    try {
+      await _secureStorage.delete(key: _kCloudProviderConfigJson);
+      state = state.copyWith(clearConfig: true);
+    } catch (e) {
+      debugPrint('CloudProviderNotifier: clearConfig failed: $e');
+      rethrow;
+    }
+  }
+
+  /// Change the routing mode without touching the stored config.
+  Future<void> setMode(CloudRoutingMode mode) async {
+    await awaitInitialLoad();
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_kCloudRoutingMode, mode.wireName);
+      state = state.copyWith(mode: mode);
+    } catch (e) {
+      debugPrint('CloudProviderNotifier: setMode failed: $e');
+      rethrow;
+    }
+  }
+}
+
+final cloudProviderNotifierProvider =
+    NotifierProvider<CloudProviderNotifier, CloudProviderState>(
+  CloudProviderNotifier.new,
+);

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_gemma/flutter_gemma_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_gemma_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterGemmaPlugin");
   flutter_gemma_plugin_register_with_registrar(flutter_gemma_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_gemma
+  flutter_secure_storage_linux
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import flutter_gemma
+import flutter_secure_storage_macos
 import flutter_tts
 import package_info_plus
 import shared_preferences_foundation
@@ -14,6 +15,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterGemmaPlugin.register(with: registry.registrar(forPlugin: "FlutterGemmaPlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -235,6 +235,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -388,6 +436,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,10 @@ dependencies:
   # SHA-256 for embedding cache invalidation keys. Lightweight, dart-only.
   crypto: ^3.0.6
   shared_preferences: ^2.5.0
+  # Android Keystore-backed encrypted storage for BYOK cloud API keys.
+  # Values are encrypted with a hardware-bound key; see README for the
+  # rooted-device caveat (flutter_secure_storage#947).
+  flutter_secure_storage: ^9.2.2
   path_provider: ^2.1.0
   forui: ^0.20.4
   flutter_riverpod: ^3.3.1

--- a/test/services/cloud/cloud_provider_config_test.dart
+++ b/test/services/cloud/cloud_provider_config_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hark/services/cloud/cloud_provider_config.dart';
+
+void main() {
+  group('CloudProviderConfig round-trip', () {
+    test('OpenAiConfig round-trips with defaults', () {
+      const cfg = OpenAiConfig(apiKey: 'sk-test');
+      expect(cfg.model, 'gpt-4o-mini');
+      expect(cfg.baseUrl, 'https://api.openai.com/v1');
+
+      final restored = CloudProviderConfig.fromJson(cfg.toJson());
+      expect(restored, isA<OpenAiConfig>());
+      expect(restored.apiKey, 'sk-test');
+      expect(restored.model, 'gpt-4o-mini');
+      expect(restored.kind, CloudProviderKind.openai);
+    });
+
+    test('OpenAiConfig round-trips with custom model', () {
+      const cfg = OpenAiConfig(apiKey: 'sk-test', model: 'gpt-4o');
+      final restored = CloudProviderConfig.fromJson(cfg.toJson());
+      expect(restored.model, 'gpt-4o');
+    });
+
+    test('AzureConfig round-trips with all fields', () {
+      const cfg = AzureConfig(
+        apiKey: 'az-test',
+        resourceName: 'my-resource',
+        model: 'hark-extract-mini',
+        apiVersion: '2024-12-01',
+      );
+      expect(
+        cfg.baseUrl,
+        'https://my-resource.openai.azure.com/openai/v1',
+      );
+
+      final json = cfg.toJson();
+      expect(json['kind'], 'azure');
+      expect(json['resource_name'], 'my-resource');
+      expect(json['api_version'], '2024-12-01');
+
+      final restored = CloudProviderConfig.fromJson(json) as AzureConfig;
+      expect(restored.apiKey, 'az-test');
+      expect(restored.resourceName, 'my-resource');
+      expect(restored.model, 'hark-extract-mini');
+      expect(restored.apiVersion, '2024-12-01');
+    });
+
+    test('AzureConfig.fromJson defaults missing api_version', () {
+      final json = {
+        'kind': 'azure',
+        'api_key': 'az',
+        'model': 'gpt-4o-mini',
+        'resource_name': 'r',
+      };
+      final restored = CloudProviderConfig.fromJson(json) as AzureConfig;
+      expect(restored.apiVersion, '2024-10-21');
+    });
+
+    test('GeminiConfig round-trips with defaults', () {
+      const cfg = GeminiConfig(apiKey: 'gm-test');
+      expect(cfg.model, 'gemini-2.5-flash-lite');
+      expect(
+        cfg.baseUrl,
+        'https://generativelanguage.googleapis.com/v1beta/openai',
+      );
+
+      final restored = CloudProviderConfig.fromJson(cfg.toJson());
+      expect(restored, isA<GeminiConfig>());
+      expect(restored.model, 'gemini-2.5-flash-lite');
+    });
+
+    test('AnthropicConfig round-trips with defaults', () {
+      const cfg = AnthropicConfig(apiKey: 'ant-test');
+      expect(cfg.model, 'claude-haiku-4-5');
+      expect(cfg.baseUrl, 'https://api.anthropic.com/v1');
+
+      final restored = CloudProviderConfig.fromJson(cfg.toJson());
+      expect(restored, isA<AnthropicConfig>());
+    });
+
+    test('CustomOpenAiConfig round-trips with user-supplied URL', () {
+      const cfg = CustomOpenAiConfig(
+        apiKey: 'or-test',
+        model: 'mistral-7b',
+        customBaseUrl: 'https://openrouter.ai/api/v1',
+      );
+      expect(cfg.baseUrl, 'https://openrouter.ai/api/v1');
+
+      final restored =
+          CloudProviderConfig.fromJson(cfg.toJson()) as CustomOpenAiConfig;
+      expect(restored.customBaseUrl, 'https://openrouter.ai/api/v1');
+      expect(restored.model, 'mistral-7b');
+    });
+  });
+
+  group('CloudProviderConfig.fromJsonString defensive parsing', () {
+    test('null input returns null', () {
+      expect(CloudProviderConfig.fromJsonString(null), isNull);
+    });
+
+    test('empty string returns null', () {
+      expect(CloudProviderConfig.fromJsonString(''), isNull);
+    });
+
+    test('malformed JSON returns null (does not throw)', () {
+      expect(CloudProviderConfig.fromJsonString('not json'), isNull);
+      expect(CloudProviderConfig.fromJsonString('{incomplete'), isNull);
+    });
+
+    test('unknown kind returns null', () {
+      const raw = '{"kind": "nonexistent", "api_key": "x", "model": "y"}';
+      expect(CloudProviderConfig.fromJsonString(raw), isNull);
+    });
+
+    test('missing required field returns null', () {
+      // AzureConfig requires resource_name — missing field surfaces as
+      // a TypeError during field extraction, caught by fromJsonString.
+      const raw = '{"kind": "azure", "api_key": "x", "model": "y"}';
+      expect(CloudProviderConfig.fromJsonString(raw), isNull);
+    });
+
+    test('valid round-trip via toJsonString / fromJsonString', () {
+      const cfg = OpenAiConfig(apiKey: 'sk-test');
+      final raw = cfg.toJsonString();
+      final restored = CloudProviderConfig.fromJsonString(raw);
+      expect(restored, isNotNull);
+      expect(restored, isA<OpenAiConfig>());
+      expect(restored!.apiKey, 'sk-test');
+    });
+  });
+
+  group('CloudProviderKind / CloudRoutingMode wire names', () {
+    test('CloudProviderKind.fromWireName round-trips all values', () {
+      for (final kind in CloudProviderKind.values) {
+        expect(
+          CloudProviderKind.fromWireName(kind.wireName),
+          kind,
+        );
+      }
+    });
+
+    test('CloudProviderKind.fromWireName throws on unknown', () {
+      expect(
+        () => CloudProviderKind.fromWireName('bogus'),
+        throwsArgumentError,
+      );
+    });
+
+    test('CloudRoutingMode.fromWireName round-trips all values', () {
+      for (final mode in CloudRoutingMode.values) {
+        expect(
+          CloudRoutingMode.fromWireName(mode.wireName),
+          mode,
+        );
+      }
+    });
+
+    test('wire names are stable (regression guard for persistence)', () {
+      // These strings are burnt into secure storage blobs. Changing them
+      // without a migration breaks every existing install.
+      expect(CloudProviderKind.openai.wireName, 'openai');
+      expect(CloudProviderKind.azureOpenAi.wireName, 'azure');
+      expect(CloudProviderKind.gemini.wireName, 'gemini');
+      expect(CloudProviderKind.anthropic.wireName, 'anthropic');
+      expect(CloudProviderKind.customOpenAi.wireName, 'custom_openai');
+
+      expect(CloudRoutingMode.localOnly.wireName, 'local_only');
+      expect(CloudRoutingMode.cloudPreferred.wireName, 'cloud_preferred');
+      expect(CloudRoutingMode.cloudOnly.wireName, 'cloud_only');
+    });
+  });
+}

--- a/test/services/cloud/cloud_provider_config_test.dart
+++ b/test/services/cloud/cloud_provider_config_test.dart
@@ -3,92 +3,82 @@ import 'package:hark/services/cloud/cloud_provider_config.dart';
 
 void main() {
   group('CloudProviderConfig round-trip', () {
-    test('OpenAiConfig round-trips with defaults', () {
-      const cfg = OpenAiConfig(apiKey: 'sk-test');
-      expect(cfg.model, 'gpt-4o-mini');
-      expect(cfg.baseUrl, 'https://api.openai.com/v1');
-
+    test('OpenAiConfig round-trips', () {
+      const cfg = OpenAiConfig(
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+        model: 'gpt-4o-mini',
+      );
       final restored = CloudProviderConfig.fromJson(cfg.toJson());
       expect(restored, isA<OpenAiConfig>());
+      expect(restored.baseUrl, 'https://api.openai.com/v1');
       expect(restored.apiKey, 'sk-test');
       expect(restored.model, 'gpt-4o-mini');
       expect(restored.kind, CloudProviderKind.openai);
     });
 
-    test('OpenAiConfig round-trips with custom model', () {
-      const cfg = OpenAiConfig(apiKey: 'sk-test', model: 'gpt-4o');
-      final restored = CloudProviderConfig.fromJson(cfg.toJson());
-      expect(restored.model, 'gpt-4o');
-    });
-
     test('AzureConfig round-trips with all fields', () {
       const cfg = AzureConfig(
+        baseUrl: 'https://my-resource.openai.azure.com/openai/v1',
         apiKey: 'az-test',
-        resourceName: 'my-resource',
         model: 'hark-extract-mini',
         apiVersion: '2024-12-01',
-      );
-      expect(
-        cfg.baseUrl,
-        'https://my-resource.openai.azure.com/openai/v1',
       );
 
       final json = cfg.toJson();
       expect(json['kind'], 'azure');
-      expect(json['resource_name'], 'my-resource');
+      expect(
+        json['base_url'],
+        'https://my-resource.openai.azure.com/openai/v1',
+      );
       expect(json['api_version'], '2024-12-01');
 
       final restored = CloudProviderConfig.fromJson(json) as AzureConfig;
+      expect(
+        restored.baseUrl,
+        'https://my-resource.openai.azure.com/openai/v1',
+      );
       expect(restored.apiKey, 'az-test');
-      expect(restored.resourceName, 'my-resource');
       expect(restored.model, 'hark-extract-mini');
       expect(restored.apiVersion, '2024-12-01');
     });
 
-    test('AzureConfig.fromJson defaults missing api_version', () {
-      final json = {
-        'kind': 'azure',
-        'api_key': 'az',
-        'model': 'gpt-4o-mini',
-        'resource_name': 'r',
-      };
-      final restored = CloudProviderConfig.fromJson(json) as AzureConfig;
-      expect(restored.apiVersion, '2024-10-21');
-    });
-
-    test('GeminiConfig round-trips with defaults', () {
-      const cfg = GeminiConfig(apiKey: 'gm-test');
-      expect(cfg.model, 'gemini-2.5-flash-lite');
-      expect(
-        cfg.baseUrl,
-        'https://generativelanguage.googleapis.com/v1beta/openai',
+    test('GeminiConfig round-trips', () {
+      const cfg = GeminiConfig(
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+        apiKey: 'gm-test',
+        model: 'gemini-2.5-flash-lite',
       );
-
       final restored = CloudProviderConfig.fromJson(cfg.toJson());
       expect(restored, isA<GeminiConfig>());
+      expect(
+        restored.baseUrl,
+        'https://generativelanguage.googleapis.com/v1beta/openai',
+      );
       expect(restored.model, 'gemini-2.5-flash-lite');
     });
 
-    test('AnthropicConfig round-trips with defaults', () {
-      const cfg = AnthropicConfig(apiKey: 'ant-test');
-      expect(cfg.model, 'claude-haiku-4-5');
-      expect(cfg.baseUrl, 'https://api.anthropic.com/v1');
-
+    test('AnthropicConfig round-trips', () {
+      const cfg = AnthropicConfig(
+        baseUrl: 'https://api.anthropic.com/v1',
+        apiKey: 'ant-test',
+        model: 'claude-haiku-4-5',
+      );
       final restored = CloudProviderConfig.fromJson(cfg.toJson());
       expect(restored, isA<AnthropicConfig>());
+      expect(restored.baseUrl, 'https://api.anthropic.com/v1');
+      expect(restored.model, 'claude-haiku-4-5');
     });
 
-    test('CustomOpenAiConfig round-trips with user-supplied URL', () {
+    test('CustomOpenAiConfig round-trips', () {
       const cfg = CustomOpenAiConfig(
+        baseUrl: 'https://openrouter.ai/api/v1',
         apiKey: 'or-test',
         model: 'mistral-7b',
-        customBaseUrl: 'https://openrouter.ai/api/v1',
       );
-      expect(cfg.baseUrl, 'https://openrouter.ai/api/v1');
-
       final restored =
           CloudProviderConfig.fromJson(cfg.toJson()) as CustomOpenAiConfig;
-      expect(restored.customBaseUrl, 'https://openrouter.ai/api/v1');
+      expect(restored.baseUrl, 'https://openrouter.ai/api/v1');
       expect(restored.model, 'mistral-7b');
     });
   });
@@ -108,19 +98,31 @@ void main() {
     });
 
     test('unknown kind returns null', () {
-      const raw = '{"kind": "nonexistent", "api_key": "x", "model": "y"}';
+      const raw =
+          '{"kind": "nonexistent", "base_url": "x", "api_key": "y", "model": "z"}';
       expect(CloudProviderConfig.fromJsonString(raw), isNull);
     });
 
     test('missing required field returns null', () {
-      // AzureConfig requires resource_name — missing field surfaces as
+      // AzureConfig requires api_version — missing field surfaces as
       // a TypeError during field extraction, caught by fromJsonString.
-      const raw = '{"kind": "azure", "api_key": "x", "model": "y"}';
+      const raw =
+          '{"kind": "azure", "base_url": "x", "api_key": "y", "model": "z"}';
+      expect(CloudProviderConfig.fromJsonString(raw), isNull);
+    });
+
+    test('missing base_url returns null', () {
+      const raw =
+          '{"kind": "openai", "api_key": "sk-test", "model": "gpt-4o-mini"}';
       expect(CloudProviderConfig.fromJsonString(raw), isNull);
     });
 
     test('valid round-trip via toJsonString / fromJsonString', () {
-      const cfg = OpenAiConfig(apiKey: 'sk-test');
+      const cfg = OpenAiConfig(
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+        model: 'gpt-4o-mini',
+      );
       final raw = cfg.toJsonString();
       final restored = CloudProviderConfig.fromJsonString(raw);
       expect(restored, isNotNull);
@@ -129,13 +131,23 @@ void main() {
     });
   });
 
+  group('CloudProviderConfig.toString redacts apiKey', () {
+    test('does not include apiKey', () {
+      const cfg = OpenAiConfig(
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-very-secret-key',
+        model: 'gpt-4o-mini',
+      );
+      expect(cfg.toString(), isNot(contains('sk-very-secret-key')));
+      expect(cfg.toString(), contains('<redacted>'));
+      expect(cfg.toString(), contains('gpt-4o-mini'));
+    });
+  });
+
   group('CloudProviderKind / CloudRoutingMode wire names', () {
     test('CloudProviderKind.fromWireName round-trips all values', () {
       for (final kind in CloudProviderKind.values) {
-        expect(
-          CloudProviderKind.fromWireName(kind.wireName),
-          kind,
-        );
+        expect(CloudProviderKind.fromWireName(kind.wireName), kind);
       }
     });
 
@@ -148,10 +160,7 @@ void main() {
 
     test('CloudRoutingMode.fromWireName round-trips all values', () {
       for (final mode in CloudRoutingMode.values) {
-        expect(
-          CloudRoutingMode.fromWireName(mode.wireName),
-          mode,
-        );
+        expect(CloudRoutingMode.fromWireName(mode.wireName), mode);
       }
     });
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_gemma/flutter_gemma_plugin.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_tts/flutter_tts_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <speech_to_text_windows/speech_to_text_windows.h>
@@ -15,6 +16,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterGemmaPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterGemmaPlugin"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FlutterTtsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterTtsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_gemma
+  flutter_secure_storage_windows
   flutter_tts
   permission_handler_windows
   speech_to_text_windows


### PR DESCRIPTION
## Summary

Foundations for the BYOK cloud-brain work. **No routing changes yet** — Slice 4 wires this into the resolver. This PR adds the storage layer and the data model only.

- Add `flutter_secure_storage ^9.2.2` (Android Keystore-backed AES via EncryptedSharedPreferences)
- Define `CloudProviderConfig` sealed union with concrete subclasses for OpenAI, Azure, Gemini, Anthropic, and Custom OpenAI-compatible endpoints
- `CloudRoutingMode` enum: \`local_only\` / \`cloud_preferred\` / \`cloud_only\`
- `CloudProviderNotifier` (Riverpod) owns config + mode, reads secure storage on build, persists eagerly

## Storage split

- **Secure storage:** the full config blob as a single JSON string. Atomic read/write. API key never leaves this file.
- **SharedPreferences:** only the routing mode enum. Non-sensitive, easier to clear independently of the config blob.

## Why a plain `Notifier`, not `AsyncNotifier`

The resolver needs to read the current cloud config synchronously during slot fill (Slice 4). \`AsyncNotifier\` would force every resolve to await. Initial load is tiny (one prefs read + one secure-storage read) and can be blocked on via \`awaitInitialLoad()\` during app init.

## Provider subclasses

| Kind | Handled by | Base URL |
|---|---|---|
| \`openai\` | OpenAiCompatibleAdapter (Slice 3) | \`https://api.openai.com/v1\` |
| \`azure\` | OpenAiCompatibleAdapter (Slice 3) | \`https://{resource}.openai.azure.com/openai/v1\` (v1/Foundry surface) |
| \`gemini\` | OpenAiCompatibleAdapter (Slice 3) | \`https://generativelanguage.googleapis.com/v1beta/openai\` |
| \`anthropic\` | AnthropicAdapter (Slice 7) | \`https://api.anthropic.com/v1\` |
| \`custom_openai\` | OpenAiCompatibleAdapter (Slice 3) | user-supplied |

## Files

- \`pubspec.yaml\` / \`pubspec.lock\` — dep + regenerated lock + desktop plugin registrants (flutter_secure_storage has Linux/macOS/Windows plugins)
- \`lib/services/cloud/cloud_provider_config.dart\` — sealed union + JSON (de)serialization
- \`lib/state/cloud_provider_notifier.dart\` — Riverpod notifier + secure storage glue

## Test plan

Nothing to test on device yet — this PR adds no wired behavior. Verification happens in Slice 4 when \`commandResolverProvider\` starts reading \`cloudProviderNotifierProvider\`.

- [x] \`dart analyze\` clean on new + touched files
- [x] Pub resolves cleanly with the new dep
- [ ] Smoke-load the app in release to confirm the new dep does not break build / startup

## Next slice

Slice 2 — \`HarkLlmClient\` interface + OACP→JSON-Schema translator + extract \`SlotResultValidator\` from \`slot_filling_notifier.dart\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)