### PR TITLE
feat(cloud): wire cloud slot fill into resolver (BYOK Slice 4)

### DIFF
--- a/lib/services/cloud/cloud_slot_filler.dart
+++ b/lib/services/cloud/cloud_slot_filler.dart
@@ -1,0 +1,44 @@
+import '../../models/assistant_action.dart';
+import '../nlu_command_resolver.dart';
+import 'cloud_errors.dart';
+import 'hark_llm_client.dart';
+
+/// Adapts a [HarkLlmClient] to the resolver's [SlotFillFn] contract.
+///
+/// Wraps the client's `extract()` call so the resolver receives a
+/// [SlotFillOutcome] tagged with the right backend identifier
+/// (`openai_compat`, `anthropic`, `cache`, etc.) for telemetry. The
+/// underlying client retains its own typed-error semantics —
+/// [CloudUnavailableError] / [CloudHardError] propagate through so the
+/// resolver wiring (in `resolver_provider.dart`) can decide whether to
+/// fall back to the local slot filler or surface a hard error.
+class CloudSlotFiller {
+  const CloudSlotFiller({
+    required this.client,
+    required this.backend,
+  });
+
+  final HarkLlmClient client;
+
+  /// Stable backend identifier for telemetry (`openai_compat`,
+  /// `anthropic`, etc.). The resolver writes this to the `stage2_backend`
+  /// metric so we can compare cloud vs local latency in the inference log.
+  final String backend;
+
+  /// Run the cloud extraction. On success returns a [SlotFillOutcome]
+  /// with `params` set (or null if the model returned a result that
+  /// failed schema validation — equivalent to local `slot_filling_failed`).
+  ///
+  /// On any [CloudUnavailableError] / [CloudHardError] the exception
+  /// propagates — the caller decides whether to fall back.
+  Future<SlotFillOutcome> extract({
+    required String transcript,
+    required AssistantAction action,
+  }) async {
+    final params = await client.extract(
+      transcript: transcript,
+      action: action,
+    );
+    return SlotFillOutcome(params: params, backend: backend);
+  }
+}

--- a/lib/services/nlu_command_resolver.dart
+++ b/lib/services/nlu_command_resolver.dart
@@ -13,9 +13,29 @@ import 'embedding_cache_store.dart';
 /// Async callable that embeds a query string and returns a vector.
 typedef EmbedFn = Future<List<double>?> Function(String text);
 
+/// Wraps the result of a slot-fill call so the resolver can record
+/// which backend produced the parameters in its per-stage metrics.
+///
+/// `params` is null when extraction failed (required slots missing,
+/// model returned malformed JSON, etc) — same null contract as the
+/// previous SlotFillFn shape. `backend` is a short identifier:
+/// `qwen3_local`, `openai_compat`, `anthropic`, `cache`, etc.
+class SlotFillOutcome {
+  const SlotFillOutcome({required this.params, required this.backend});
+
+  final Map<String, dynamic>? params;
+  final String backend;
+}
+
 /// Async callable that extracts parameters for a resolved action from a
-/// transcript, or returns null if required slots could not be filled.
-typedef SlotFillFn = Future<Map<String, dynamic>?> Function({
+/// transcript. Returns a [SlotFillOutcome] whose `params` field is null
+/// if required slots could not be filled.
+///
+/// Implementations may throw to signal hard failures (e.g.
+/// CloudUnavailableError / CloudHardError from cloud adapters) — the
+/// resolver still preserves the existing `StateError → unavailable`
+/// path for backward compatibility.
+typedef SlotFillFn = Future<SlotFillOutcome> Function({
   required String transcript,
   required AssistantAction action,
 });
@@ -196,21 +216,21 @@ class NluCommandResolver implements CommandResolver {
       );
     }
 
-    // Layer 2: Slot filling via on-device LLM.
-    // TODO(byok): when cloud routing lands, the backend label here will be
-    // determined by which slotFill closure was injected, not hardcoded.
+    // Layer 2: Slot filling via injected closure (local Qwen3, cloud
+    // adapter, or composite). The closure is responsible for choosing
+    // the backend; we just record which one it used.
     final action = best.action;
-    final Map<String, dynamic>? parameters;
+    final SlotFillOutcome outcome;
     final swStage2 = Stopwatch()..start();
     try {
-      parameters = await slotFill(
+      outcome = await slotFill(
         transcript: transcript,
         action: action,
       );
     } on StateError {
       swStage2.stop();
       metrics['stage2_ms'] = swStage2.elapsedMilliseconds;
-      metrics['stage2_backend'] = 'qwen3_local';
+      metrics['stage2_backend'] = 'unavailable';
       _debugLog('resolve_declined', {
         'transcript': transcript,
         'modelId': modelId,
@@ -226,7 +246,8 @@ class NluCommandResolver implements CommandResolver {
     }
     swStage2.stop();
     metrics['stage2_ms'] = swStage2.elapsedMilliseconds;
-    metrics['stage2_backend'] = 'qwen3_local';
+    metrics['stage2_backend'] = outcome.backend;
+    final parameters = outcome.params;
 
     if (parameters == null) {
       _debugLog('resolve_declined', {

--- a/lib/state/cloud_slot_filler_provider.dart
+++ b/lib/state/cloud_slot_filler_provider.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/cloud/adapters/openai_compatible_adapter.dart';
+import '../services/cloud/cloud_provider_config.dart';
+import '../services/cloud/cloud_slot_filler.dart';
+import 'cloud_provider_notifier.dart';
+
+/// Compile-time Azure bootstrap for first-pass on-device testing
+/// without a settings UI (Slice 5 will replace this with the real
+/// Cloud Brain screen).
+///
+/// Pass these via the flutter run command:
+///
+/// ```
+/// flutter run --release \
+///   --dart-define=AZURE_BASE_URL=https://hark-ai-resource.cognitiveservices.azure.com/openai/deployments/hark-cloud-gpt-4-mini \
+///   --dart-define=AZURE_API_KEY=<key> \
+///   --dart-define=AZURE_MODEL=hark-cloud-gpt-4-mini \
+///   --dart-define=AZURE_API_VERSION=2025-01-01-preview
+/// ```
+///
+/// All four values must be supplied for the env-var path to activate.
+/// Empty defaults mean "not configured" — the provider falls back to
+/// the secure-storage-backed [CloudProviderNotifier] state instead.
+const _envBaseUrl = String.fromEnvironment('AZURE_BASE_URL');
+const _envApiKey = String.fromEnvironment('AZURE_API_KEY');
+const _envModel = String.fromEnvironment('AZURE_MODEL');
+const _envApiVersion = String.fromEnvironment('AZURE_API_VERSION');
+
+CloudProviderConfig? _envConfigOrNull() {
+  if (_envBaseUrl.isEmpty ||
+      _envApiKey.isEmpty ||
+      _envModel.isEmpty ||
+      _envApiVersion.isEmpty) {
+    return null;
+  }
+  return AzureConfig(
+    baseUrl: _envBaseUrl,
+    apiKey: _envApiKey,
+    model: _envModel,
+    apiVersion: _envApiVersion,
+  );
+}
+
+/// Builds a [CloudSlotFiller] from whichever cloud config source has
+/// one to offer. Source precedence:
+///
+/// 1. **`--dart-define` AZURE_* values** (compile-time, dev-only) — for
+///    rapid iteration without committing keys to git or building a UI
+/// 2. **`CloudProviderNotifier` state** — the proper secure-storage
+///    path that Slice 5's settings screen will populate
+///
+/// Emits `null` when neither source has a config. Watching consumers
+/// must treat null as "no cloud configured" and fall back to local.
+///
+/// This provider is `keepAlive`-style by virtue of being a top-level
+/// `Provider` — it rebuilds when [cloudProviderNotifierProvider] emits.
+final cloudSlotFillerProvider = Provider<CloudSlotFiller?>((ref) {
+  // Source 1: env vars (debug bootstrap)
+  final envConfig = _envConfigOrNull();
+  if (envConfig != null) {
+    debugPrint(
+      'cloudSlotFillerProvider: using --dart-define AZURE bootstrap '
+      '(baseUrl=${envConfig.baseUrl}, model=${envConfig.model})',
+    );
+    final adapter = OpenAiCompatibleAdapter(envConfig);
+    ref.onDispose(adapter.close);
+    return CloudSlotFiller(client: adapter, backend: 'openai_compat');
+  }
+
+  // Source 2: secure-storage notifier
+  final state = ref.watch(cloudProviderNotifierProvider);
+  final config = state.config;
+  if (config == null) return null;
+
+  // Anthropic needs the dedicated adapter (Slice 7) — not handled here.
+  if (config.kind == CloudProviderKind.anthropic) {
+    debugPrint(
+      'cloudSlotFillerProvider: anthropic config present but '
+      'AnthropicAdapter not implemented yet (Slice 7). Falling back.',
+    );
+    return null;
+  }
+
+  debugPrint(
+    'cloudSlotFillerProvider: using stored config '
+    '(kind=${config.kind.wireName}, baseUrl=${config.baseUrl}, '
+    'model=${config.model})',
+  );
+  final adapter = OpenAiCompatibleAdapter(config);
+  ref.onDispose(adapter.close);
+  return CloudSlotFiller(client: adapter, backend: 'openai_compat');
+});

--- a/lib/state/cloud_slot_filler_provider.dart
+++ b/lib/state/cloud_slot_filler_provider.dart
@@ -43,6 +43,16 @@ CloudProviderConfig? _envConfigOrNull() {
   );
 }
 
+/// True when the compile-time AZURE_* dart-defines are all set. The
+/// resolver wiring treats this as an implicit `cloudPreferred` mode
+/// override so a developer running with env vars doesn't also have to
+/// flip a mode toggle that doesn't have a UI yet.
+bool get hasEnvCloudBootstrap =>
+    _envBaseUrl.isNotEmpty &&
+    _envApiKey.isNotEmpty &&
+    _envModel.isNotEmpty &&
+    _envApiVersion.isNotEmpty;
+
 /// Builds a [CloudSlotFiller] from whichever cloud config source has
 /// one to offer. Source precedence:
 ///

--- a/lib/state/resolver_provider.dart
+++ b/lib/state/resolver_provider.dart
@@ -1,15 +1,21 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../services/cloud/cloud_errors.dart';
+import '../services/cloud/cloud_provider_config.dart';
 import '../services/command_resolver.dart';
 import '../services/embedding_cache_store.dart';
 import '../services/logging_command_resolver.dart';
 import '../services/nlu_command_resolver.dart';
+import 'cloud_provider_notifier.dart';
+import 'cloud_slot_filler_provider.dart';
 import 'embedding_notifier.dart';
 import 'services_providers.dart';
 import 'slot_filling_notifier.dart';
 
 /// Wires [LoggingCommandResolver] → [NluCommandResolver] to the Riverpod
-/// notifiers that own the embedding and slot-filling models.
+/// notifiers that own the embedding, slot-filling, and (optionally)
+/// cloud slot-filling models.
 ///
 /// The resolver is Riverpod-agnostic: it takes closures that call into the
 /// notifiers via `ref.read`, keeping the NLU logic trivially unit-testable.
@@ -17,17 +23,71 @@ import 'slot_filling_notifier.dart';
 /// The [EmbeddingCacheStore] persists action document embeddings to disk
 /// so subsequent cold starts skip the ~7s re-embedding pass that otherwise
 /// runs on the first voice command. See Phase 2b-2 of the near-term plan.
+///
+/// **Slot-fill routing (Slice 4):**
+///
+/// The `slotFill` closure picks local vs cloud at call time based on
+/// the user's [CloudRoutingMode]. Modes:
+///
+/// - `localOnly` (default when no key configured) → always local Qwen3
+/// - `cloudPreferred` → cloud first; fall back to local on any
+///   [CloudUnavailableError]; rethrow [CloudHardError]
+/// - `cloudOnly` → cloud or fail (no silent fallback)
+///
+/// In all cases the closure returns a [SlotFillOutcome] tagged with the
+/// backend that actually produced the params, which the resolver writes
+/// to the `stage2_backend` metric.
 final commandResolverProvider = Provider<CommandResolver>((ref) {
   final logger = ref.watch(inferenceLoggerProvider);
+
+  Future<SlotFillOutcome> localSlotFill({
+    required String transcript,
+    required action,
+  }) async {
+    final params = await ref
+        .read(slotFillingProvider.notifier)
+        .extractParameters(transcript: transcript, action: action);
+    return SlotFillOutcome(params: params, backend: 'qwen3_local');
+  }
 
   final nlu = NluCommandResolver(
     embedQuery: (text) async =>
         ref.read(embeddingProvider.notifier).embedQuery(text),
     embedDocument: (text) async =>
         ref.read(embeddingProvider.notifier).embedDocument(text),
-    slotFill: ({required transcript, required action}) async => ref
-        .read(slotFillingProvider.notifier)
-        .extractParameters(transcript: transcript, action: action),
+    slotFill: ({required transcript, required action}) async {
+      final mode = ref.read(cloudProviderNotifierProvider).mode;
+      final cloud = ref.read(cloudSlotFillerProvider);
+
+      // No cloud configured OR user wants local-only → straight to local.
+      if (cloud == null || mode == CloudRoutingMode.localOnly) {
+        return localSlotFill(transcript: transcript, action: action);
+      }
+
+      // Cloud path. Catch only the recoverable error type so hard errors
+      // (CloudHardError, programmer errors) propagate to the user.
+      try {
+        return await cloud.extract(
+          transcript: transcript,
+          action: action,
+        );
+      } on CloudUnavailableError catch (e) {
+        if (mode == CloudRoutingMode.cloudPreferred) {
+          debugPrint(
+            'commandResolver: cloud unavailable in cloudPreferred mode, '
+            'falling back to local. Reason: $e',
+          );
+          return localSlotFill(transcript: transcript, action: action);
+        }
+        // cloudOnly → surface as StateError so existing
+        // NluCommandResolver.unavailable path handles it.
+        debugPrint(
+          'commandResolver: cloud unavailable in cloudOnly mode. '
+          'Reason: $e',
+        );
+        throw StateError('Cloud unavailable: ${e.message}');
+      }
+    },
     modelId: EmbeddingNotifier.modelId,
     cacheStore: EmbeddingCacheStore(modelId: EmbeddingNotifier.modelId),
   );

--- a/lib/state/resolver_provider.dart
+++ b/lib/state/resolver_provider.dart
@@ -56,7 +56,14 @@ final commandResolverProvider = Provider<CommandResolver>((ref) {
     embedDocument: (text) async =>
         ref.read(embeddingProvider.notifier).embedDocument(text),
     slotFill: ({required transcript, required action}) async {
-      final mode = ref.read(cloudProviderNotifierProvider).mode;
+      // Env-bootstrap (--dart-define AZURE_*) overrides the stored mode
+      // so a developer running locally for first-pass cloud telemetry
+      // gets cloud-preferred behavior without a settings UI. Once the
+      // Cloud Brain screen lands in Slice 5, the stored mode wins.
+      final storedMode = ref.read(cloudProviderNotifierProvider).mode;
+      final mode = hasEnvCloudBootstrap
+          ? CloudRoutingMode.cloudPreferred
+          : storedMode;
       final cloud = ref.read(cloudSlotFillerProvider);
 
       // No cloud configured OR user wants local-only → straight to local.


### PR DESCRIPTION
## Summary

Cloud telemetry path is now live. Stage 2 picks **local Qwen3** or the **cloud OpenAiCompatibleAdapter** at call time based on the user's \`CloudRoutingMode\`.

This is the slice that finally lets us measure cloud-vs-local on a real device.

## Changes

### Data shape
- New \`SlotFillOutcome { params, backend }\` wrapper so the resolver records the actual stage-2 backend in metrics instead of the hardcoded \"qwen3_local\" placeholder from Slice 0.
- \`SlotFillFn\` typedef updated to return \`SlotFillOutcome\`. Migration is mechanical — only \`resolver_provider.dart\`'s closure needed updating; \`NluCommandResolver\` callers are unaffected.

### Cloud wiring
- New \`CloudSlotFiller\` adapts \`HarkLlmClient\` (Slice 3) to the resolver's \`SlotFillFn\` shape, tagging outcomes with a backend label (\`openai_compat\` today; \`anthropic\` / \`cache\` later).
- New \`cloudSlotFillerProvider\` with two-source precedence:
  1. **\`--dart-define AZURE_*\` compile-time bootstrap** — for first-pass on-device testing without a settings UI
  2. **\`CloudProviderNotifier\` secure-storage state** — proper persistent path (Slice 1)
  Returns \`null\` when neither source has a config.

### Routing
- \`commandResolverProvider.slotFill\` closure picks local vs cloud per \`CloudRoutingMode\`:
  - \`localOnly\` → straight to Qwen3
  - \`cloudPreferred\` → cloud first; fall back to Qwen3 on \`CloudUnavailableError\`; rethrow \`CloudHardError\` as \`StateError\`
  - \`cloudOnly\` → cloud or fail
- **Env-bootstrap override:** when \`--dart-define AZURE_*\` is set, the resolver forces \`cloudPreferred\` so dev testing works without a UI for the mode toggle.

## How to test on device

```bash
flutter run --release \\
  --dart-define=AZURE_BASE_URL=https://hark-ai-resource.cognitiveservices.azure.com/openai/deployments/hark-cloud-gpt-4-mini \\
  --dart-define=AZURE_API_KEY=<key> \\
  --dart-define=AZURE_MODEL=hark-cloud-gpt-4-mini \\
  --dart-define=AZURE_API_VERSION=2025-01-01-preview
```

Then watch logcat:

```bash
adb logcat | grep -E \"HarkMetrics|HarkCloudReq|HarkCloudRes\"
```

Run a few param-carrying commands ('play yesterday by the beatles on auxio', 'set timer for five minutes', 'breezy weather today'). You should see:

- \`HarkCloudReq\` line per command with the deployment URL + transcript
- \`HarkCloudRes\` line with elapsed ms + parsed args + validated bool
- \`HarkMetrics\` line showing \`backend=openai_compat\` and a much smaller \`stage2_ms\` than the ~13–28s baseline

To verify the fallback path: airplane-mode mid-command. Should see \`CloudUnavailableError\` followed by a local Qwen3 retry, ending in a normal \`HarkMetrics\` line with \`backend=qwen3_local\`.

To verify cloud-only failure: run with a bogus \`AZURE_API_KEY=invalid\`. Should see 401 → \`CloudUnavailableError\` → fallback to Qwen3 (because env-bootstrap defaults to \`cloudPreferred\`).

## Files

| | |
|---|---|
| \`lib/services/nlu_command_resolver.dart\` | New \`SlotFillOutcome\` + updated \`SlotFillFn\` typedef + consume backend from outcome |
| \`lib/services/cloud/cloud_slot_filler.dart\` | **new** — adapter wrapping \`HarkLlmClient\` |
| \`lib/state/cloud_slot_filler_provider.dart\` | **new** — Riverpod provider with env-bootstrap fallback |
| \`lib/state/resolver_provider.dart\` | Mode-aware slotFill closure with cloud routing + fallback logic |

## Test coverage

- \`flutter analyze lib test\` clean
- \`flutter test test/services/cloud/\` 55/55 passing
- No live cloud test in CI (would need an API key); first device run is the integration test

## Next slice

Slice 5 — proper Cloud Brain settings screen so users (not just devs with --dart-define) can paste config + flip mode without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)